### PR TITLE
Grains Frequency Sweep Demo And Grain Updates

### DIFF
--- a/examples/Grains/Grains.ino
+++ b/examples/Grains/Grains.ino
@@ -1,0 +1,114 @@
+
+/**
+ * @file Grains.ino
+ *
+ * This example serves a reference point for using granular synthesis
+ * through grains.
+ * It demonstrates a frequency and amplitude sweep, duration changes,
+ * wave shape variations, and how each parameter functions in isolation.
+ */
+
+#include "VibrosonicsAPI.h"
+
+/**
+ * BACKGROUND: What is a Grain?
+ * In a nutshell, grains are tiny "slices" of audio from a larger sample.
+ * By subdividing a sample into individual grains, more sophisticated 
+ * analysis can be performed. For example, layering multiple grains on
+ * top of each other can create new soundscapes, or a particular instrument
+ * can be isolated and played over a long duration. Note that due to the
+ * fine tuned nature of granular synthesis, applying generalizations will
+ * often create "glitchy" sounds, so users will likely need to play around
+ * and experiment to achieve desired results.
+ *
+ * In Vibrosonics, grains are a layer on top of AudioLab waves to provide
+ * some additional features. These features are as follows:
+ * -- Duration modifications: Grains can be configured to run over many windows
+ *    in a flexible way, whereas AudioLab waves only run for 1 window
+ * -- Frequency and Amplitude modulation: Grains give the user the power to
+ *    modulate frequencies and amplitudes on top of existing analysis to
+ *    do things like make certain events stand out more for example.
+ * -- Wave Shaping: Through the Attack, Sustain, and Release states, grains
+ *    give the user the ability to create custom curves and wave shapes on
+ *    top of their base waveshape from AudioLab (SINE, COSINE, SQUARE, SAWTOOTH,
+ *    TRIANGLE)
+ *
+ * NOTES:
+ * In our testing, we found that grains are a bit more of a niche feature
+ * rather than being ideal as the primary synthesis method. A good
+ * example of an ideal situation for using grains are snare drums.
+ * Any instrument/vocal/tone with a long lifetime is a good canidate
+ * for using Grains.
+ * This functionality is demoed in
+ * examples/AdvancedGrains/AdvancedGrains.ino
+ */
+
+/**
+ * Instance of the Vibrosonics API. Core to all operations including:
+ * -- FFT operations with ArduinoFFT
+ * -- Audio spectrum storage with the spectrogram
+ * -- Audio input and synthesis through AudioLab
+ * -- AudioPrism module management and analysis
+ * -- Grain creation and management
+ */
+VibrosonicsAPI vapi = VibrosonicsAPI();
+
+// Creates major peaks module to analyze 4 peaks
+MajorPeaks mp = MajorPeaks();
+//Creates a grain array with 4 grains on channel 0 with the SINE wave type
+Grain* mpGrains = vapi.createGrainArray(4, 0, SINE);
+Grain* freqSweepGrains = vapi.createGrain(1, 0, SINE);
+
+/**
+ * Runs once on ESP32 startup.
+ * VibrosonicsAPI initializes AudioLab and adds modules to be managed
+ * Grain shaping should also be configured here.
+ */
+void setup()
+{
+  Serial.begin(115200);
+  vapi.init();
+  // Add any AudioPrism modules to the API here
+  vapi.addModule(&mp);
+  // Shape the MajorPeaks grains
+  vapi.setGrainAttack(mpGrains, 4, 0, 0, 2);
+  vapi.setGrainSustain(mpGrains, 4, 0, 0, 1);
+  vapi.setGrainRelease(mpGrains, 4, 0, 0, 4);
+
+}
+
+/**
+ * Main loop for analysis and synthesis.
+ * Has 5 key steps:
+ * 1. Check if AudioLab is ready
+ * 2. Process input
+ * 3. Analyze processed data
+ * 4. Generate waves with grains or through the API
+ * 5. Synthesize and output waves through AudioLab
+ */
+void loop()
+{
+  if (!AudioLab.ready()) {
+    return;
+  }
+
+  // process the input buffer
+  //vapi.processInput();
+
+  // Run module analysis
+  //vapi.analyze();
+
+  // For modules you will need to get their output to perform further manipulation
+  //float** mpData = mp.getOutput();
+
+  // Grains method
+  // With frequency and amplitude data you will want to trigger the grains
+  //vapi.triggerGrains(mpGrains, 4, mpData);
+
+  // Update grains if you are using them
+  vapi.updateGrains();
+  // Lastly, synthesize all created waves through AudioLab
+  AudioLab.synthesize();
+  // Uncomment for debugging:
+  // AudioLab.printWaves();
+}

--- a/src/Grain.cpp
+++ b/src/Grain.cpp
@@ -181,9 +181,10 @@ void Grain::transitionTo(grainState newState) {
     grainFrequency = 0.0f;
     grainAmplitude = 0.0f;
   } else if (newState == ATTACK) {
-    attack.curvePosition *= attack.incrementFactor;
+    float pos  = (float)(windowCounter + 1) / (float)attack.duration;
+    float curvedProgress = powf(pos, attack.curve);
     grainFrequency = attack.frequency + sustainAttackFrequencyDifference * attack.frequencyModulator;
-    grainAmplitude = attack.amplitude * (1.0f - powf(attack.curvePosition, attack.curve));
+    grainAmplitude = attack.amplitude * curvedProgress;
   } else if (newState == SUSTAIN) {
     grainFrequency = sustain.frequency * sustain.frequencyModulator;
     grainAmplitude = sustain.amplitude * sustain.amplitudeModulator;

--- a/src/Grain.h
+++ b/src/Grain.h
@@ -35,56 +35,59 @@ class GrainList;
   * https://en.wikipedia.org/wiki/Granular_synthesis
   *
   * https://en.wikipedia.org/wiki/Envelope_(music)
-*/
-
+  */
 class Grain {
 private:
   struct Phase {
-    // Number of windows each phase runs for
+    //! Number of windows each phase runs for
     int duration = 0;
-    // Targeted frequency for the phase
+    //! Targeted frequency for the phase
     float frequency = 0.0f;
-    // Targeted amplitude for the phase
+    //! Targeted amplitude for the phase
     float amplitude = 0.0f;
-    // Modulates frequency by multiplying frequencyModulator to frequency
+    //! Modulates frequency by multiplying frequencyModulator to frequency
     float frequencyModulator = 1.0f; // Default: no modulation
-    // Modulates amplitude by multiplying amplitudeModulator to amplitude
+    //! Modulates amplitude by multiplying amplitudeModulator to amplitude
     float amplitudeModulator = 1.0f; // Default: no modulation
 
-    // Shapes the curve by raising curveStep*windowCounter to the degree of the curve value
+    //! Shapes the curve by raising curveStep*windowCounter to the degree of the curve value
     float curve = 1.0f; // Default: linear
-    // Speed that grain steps through each phase of the wave. Calculated as 1.0/duration
-    float curveStep = 1.0f; // Default: no curve step
-    // Current progression through the phase (1.0-0.0)
-    float curvePosition = 1.0f;
-    // Factor to multiplicatively increment the curvePosition
-    float incrementFactor = 1.0f;
   };
 
+  //! Struct containing attack parameters
   Phase attack;
+  //! Struct containing sustain parameters
   Phase sustain;
+  //! Struct containing release parameters
   Phase release;
 
-  float sustainAttackAmplitudeDifference;
+  //! The difference in frequency between sustain and attack
   float sustainAttackFrequencyDifference;
-  float releaseSustainAmplitudeDifference;
+  //! The difference in frequency between release and sustain
   float releaseSustainFrequencyDifference;
 
+  //! The counter for how many windows a state has run for
   int windowCounter;
 
+  //! The current amplitude of the grain
   float grainAmplitude;
+  //! The current frequency of the grain
   float grainFrequency;
 
-  // Wave parameters
+  //! The wave shape of outputted grain waves
   WaveType waveType;
 
+  //! The output channel for generated grain waves
   uint8_t grainChannel;
 
+  //! The current envelope state of the grain
   grainState state;
 
   //! Update frequency and amplitude values based on current grain state.
   void run();
 
+  //! Helper function to perform necessary operations on grain parameters
+  //! when transitioning between run states
   void transitionTo(grainState newState);
 
 public:
@@ -98,17 +101,11 @@ public:
   //! Updates grain parameters in the attack state
   void setAttack(float frequency, float amplitude, int duration);
 
-  //! Updates attack curve value.
-  void setAttackCurve(float curveValue);
-
   //! Updates grain parameters in the sustain state
   void setSustain(float frequency, float amplitude, int duration);
 
   //! Updates grain parameters in the release state
   void setRelease(float frequency, float amplitude, int duration);
-
-  //! Updates release curve value.
-  void setReleaseCurve(float curveValue);
 
   //! Sets the channel of this grain
   void setChannel(uint8_t channel);
@@ -137,11 +134,13 @@ public:
   //! Returns the release duration
   int getReleaseDuration();
 
-  // Shaper functions
+  //! Sets parameters for the attack state
   void shapeAttack(int duration, float freqMod, float ampMod, float curve);
 
+  //! Sets parameters for the sustain state
   void shapeSustain(int duration, float freqMod, float ampMod);
 
+  //! Sets parameters for the release state
   void shapeRelease(int duration, float freqMod, float ampMod, float curve);
 };
 
@@ -151,7 +150,9 @@ public:
 struct GrainNode {
   //! Default constructor.
   GrainNode(Grain *object) : reference(object), next(nullptr) {}
+  //! Reference containing grain data
   Grain *reference;
+  //! Pointer to the next grain in the list
   GrainNode *next;
 };
 
@@ -160,7 +161,9 @@ struct GrainNode {
  */
 class GrainList {
 private:
+  //! Grain at the front of the list
   GrainNode *head;
+  //! Grain at the back of the list
   GrainNode *tail;
 public:
   //! Default constructor.

--- a/src/VibrosonicsAPI.cpp
+++ b/src/VibrosonicsAPI.cpp
@@ -338,10 +338,10 @@ void VibrosonicsAPI::updateGrains()
  */
 void VibrosonicsAPI::triggerGrains(Grain* grains, int numGrains, float** moduleData)
 {
-    for (int i = 0; i < numPeaks; i++) {
+    for (int i = 0; i < numGrains; i++) {
         float currentAmp = moduleData[MP_AMP][i];
         float currentFreq = moduleData[MP_FREQ][i];
-        if(moduleData[MP_AMP][i] > grains[i].getFrequency()){
+        if(currentAmp > grains[i].getAmplitude()){
             grains[i].setAttack(currentFreq, currentAmp, grains[i].getAttackDuration());
             grains[i].setSustain(currentFreq, currentAmp, grains[i].getSustainDuration());
             grains[i].setRelease(currentFreq, 0, grains[i].getReleaseDuration());

--- a/src/VibrosonicsAPI.cpp
+++ b/src/VibrosonicsAPI.cpp
@@ -321,19 +321,6 @@ Grain* VibrosonicsAPI::createGrainArray(int numGrains, uint8_t channel, WaveType
 }
 
 /**
- * Creates a singular grain with specified channel and wave type and then pushes the
- * newly created grain to the global grain list.
- *
- * @param channel The physical speaker channel, on current hardware valid inputs are 0-2
- * @param waveType The type of wave Audiolab will generate utilizing the grains.
- */
-
-Grain* VibrosonicsAPI::createGrain(uint8_t channel, WaveType waveType)
-{
-    return createGrainArray(1, channel, waveType);
-}
-
-/**
  * Calls update for every grain in the grain list
  */
 void VibrosonicsAPI::updateGrains()
@@ -342,67 +329,36 @@ void VibrosonicsAPI::updateGrains()
 }
 
 /**
- * Updates an array of numPeaks grains sustain and release windows if
+ * Updates an array of grains attack, sustain, and release windows if
  * the data's amplitude is greater than the amplitude stored in the grain.
  *
- * @param numPeaks The size of the Grain array.
- * @param peakData A pointer to a module's amplitude data
  * @param grains An array of grains to be triggered.
+ * @param numGrains The size of the Grain array.
+ * @param moduleData A pointer to a module's frequency and amplitude data
  */
-
-void VibrosonicsAPI::triggerGrains(Grain* grains, int numPeaks, float** peakData)
+void VibrosonicsAPI::triggerGrains(Grain* grains, int numGrains, float** moduleData)
 {
-    // NOTE: ADD FREQUENCY MATCHING
-    // Plan: First pass, check to see if incoming peakData frequencies match previous grain frequencies.
-    // So if previous grains are [200hz, 400hz, 800hz, 1600hz], and incoming data is [400hz, 800hz, 1600hz, 320hz]
-    // the grain mapping will be [320hz, 400hz, 800hz, 1600hz]. Basically make sure that each grain is actually keeping as similair a frequency as possible
-    // Keep the data in sync
-    // issue: the Just noticeable difference for people in this frequency range is 1hz. gonna have to match basically exactly.
-
-    float sortedFreqs[numPeaks];
-    float sortedAmps[numPeaks];
-
     for (int i = 0; i < numPeaks; i++) {
-        sortedFreqs[i] = peakData[MP_FREQ][i];
-        sortedAmps[i] = peakData[MP_AMP][i];
-    }
-
-    for (int i = 0; i < numPeaks - 1; i++) {
-        for (int j = 0; j < numPeaks - i - 1; j++) {
-            if (sortedFreqs[j] > sortedFreqs[j + 1]) {
-                float tempFreq = sortedFreqs[j];
-                sortedFreqs[j] = sortedFreqs[j + 1];
-                sortedFreqs[j + 1] = tempFreq;
-
-                float tempAmp = sortedAmps[j];
-                sortedAmps[j] = sortedAmps[j + 1];
-                sortedAmps[j + 1] = tempAmp;
-            }
-        }
-    }
-
-    for (int i = 0; i < numPeaks - 1; i++) {
-        for (int j = 0; j < numPeaks - i - 1; j++) {
-            if (grains[j].getFrequency() > grains[j + 1].getFrequency()) {
-                Grain temp = grains[j];
-                grains[j] = grains[j + 1];
-                grains[j + 1] = temp;
-            }
-        }
-    }
-
-    for (int i = 0; i < numPeaks; i++) {
-        float closestFreq = sortedFreqs[i];
-        float closestAmp = sortedAmps[i];
-
-        if (closestAmp >= grains[i].getAmplitude()) {
-            grains[i].setAttack(closestFreq, closestAmp, grains[i].getAttackDuration());
-            grains[i].setSustain(closestFreq, closestAmp, grains[i].getSustainDuration());
-            grains[i].setRelease(closestFreq, 0, grains[i].getReleaseDuration());
+        float currentAmp = moduleData[MP_AMP][i];
+        float currentFreq = moduleData[MP_FREQ][i];
+        if(moduleData[MP_AMP][i] > grains[i].getFrequency()){
+            grains[i].setAttack(currentFreq, currentAmp, grains[i].getAttackDuration());
+            grains[i].setSustain(currentFreq, currentAmp, grains[i].getSustainDuration());
+            grains[i].setRelease(currentFreq, 0, grains[i].getReleaseDuration());
         }
     }
 }
 
+/**
+ * Updates an array of grains parameters in the attack state.
+ *
+ * @param grains An array of grains
+ * @param numGrains The size of a grain array
+ * @param duration The number of windows the attack state will last for
+ * @param freqMod The multiplicative modulation factor for the frequency of the attack state
+ * @param ampMod The multiplicative modulation factor for the frequency of the attack state
+ * @param curve Factor to influence the shave of the progression curve of the grain
+ */
 void VibrosonicsAPI::shapeGrainAttack(Grain* grains, int numGrains, int duration, float freqMod, float ampMod, float curve)
 {
     for (int i = 0; i < numGrains; i++) {
@@ -410,6 +366,15 @@ void VibrosonicsAPI::shapeGrainAttack(Grain* grains, int numGrains, int duration
     }
 }
 
+/**
+ * Updates an array of grains parameters in the sustain state.
+ *
+ * @param grains An array of grains
+ * @param numGrains The size of a grain array
+ * @param duration The number of windows the sustain state will last for
+ * @param freqMod The multiplicative modulation factor for the frequency of the sustain state
+ * @param ampMod The multiplicative modulation factor for the frequency of the sustain state
+ */
 void VibrosonicsAPI::shapeGrainSustain(Grain* grains, int numGrains, int duration, float freqMod, float ampMod)
 {
     for (int i = 0; i < numGrains; i++) {
@@ -417,6 +382,16 @@ void VibrosonicsAPI::shapeGrainSustain(Grain* grains, int numGrains, int duratio
     }
 }
 
+/**
+ * Updates an array of grains parameters in the release state.
+ *
+ * @param grains An array of grains
+ * @param numGrains The size of a grain array
+ * @param duration The number of windows the release state will last for
+ * @param freqMod The multiplicative modulation factor for the frequency of the release state
+ * @param ampMod The multiplicative modulation factor for the frequency of the release state
+ * @param curve Factor to influence the shave of the progression curve of the grain
+ */
 void VibrosonicsAPI::shapeGrainRelease(Grain* grains, int numGrains, int duration, float freqMod, float ampMod, float curve)
 {
     for (int i = 0; i < numGrains; i++) {

--- a/src/VibrosonicsAPI.h
+++ b/src/VibrosonicsAPI.h
@@ -121,8 +121,6 @@ public:
         float freqMod, float ampMod, float curve);
 
 private:
-    // --- ArduinoFFT library ------------------------------------------------------
-
     // Fast Fourier Transform uses complex numbers
     float vReal[WINDOW_SIZE]; //!< Real component of cosine amplitude of each frequency.
     float hamming[WINDOW_SIZE]; //!< Pre computed hamming window data

--- a/src/VibrosonicsAPI.h
+++ b/src/VibrosonicsAPI.h
@@ -105,20 +105,18 @@ public:
     //! wave type.
     Grain* createGrainArray(int numGrains, uint8_t channel, WaveType waveType);
 
-    //! Creates and returns a singular grain with specified wave and channel.
-    Grain* createGrain(uint8_t channel, WaveType waveType);
-
     //! Updates an array of numPeaks grains sustain and release windows.
     void triggerGrains(Grain* grains, int numPeaks, float** peakData);
 
-    // GRAIN SHAPING
-
+    //! Sets the attack state parameters for an array of grains
     void shapeGrainAttack(Grain* grains, int numGrains, int duration,
         float freqMod, float ampMod, float curve);
 
+    //! Sets the sustain state parameters for an array of grains
     void shapeGrainSustain(Grain* grains, int numGrains, int duration,
         float freqMod, float ampMod);
 
+    //! Sets the release state parameters for an array of grains
     void shapeGrainRelease(Grain* grains, int numGrains, int duration,
         float freqMod, float ampMod, float curve);
 


### PR DESCRIPTION
### Frequency Sweep Example
---
A frequency sweep example script has been made for demoing Grains functionality as requested by Dr. Chet. The program runs a frequency sweep with long grain state windows to demonstrate the differences between states. Loops between 100hz-4000hz.
### Bug Fixes
---
- Grain curves now properly scale amplitude from 0->attack amplitude target in attack and sustained amplitude->0 in release as originally intended.
- Ready->Attack state now works as intended. Previously Ready state would run for an extra window, impacting the duration of the Attack state.
### Other Updates
---
- Ensured Grain documentation is completely updated and Doxygen compliant
- Removed redundant/unnecessary parameters and functions that were still left over from the previous iteration of grains.

Resolves #54, resolves #57 