### PR TITLE
Grains 3.0

### DIFF
--- a/examples/DynamicTest/DynamicTest.ino
+++ b/examples/DynamicTest/DynamicTest.ino
@@ -18,8 +18,8 @@ void setup() {
   Serial.begin(115200);
   vapi.init();
 
-  dynamicFreqEnv = vapi.createFreqEnv(110, 110);
-  dynamicAmpEnv = vapi.createAmpEnv(0.5, 0.0, 3, 2, 1, 3, 1.0);
+  dynamicFreqEnv = vapi.createFreqEnv(110, 110, 110, 110);
+  dynamicAmpEnv = vapi.createAmpEnv(0.5, 3, 0.5, 2, 0.4, 1, 0.0, 3, 1.0);
 }
 
 void loop() {

--- a/examples/DynamicTest/DynamicTest.ino
+++ b/examples/DynamicTest/DynamicTest.ino
@@ -1,0 +1,40 @@
+/**
+ * @file Percussion.ino
+ *
+ * This example shows how to detect percussion.
+ */
+
+#include "VibrosonicsAPI.h"
+
+VibrosonicsAPI vapi = VibrosonicsAPI();
+
+FreqEnv dynamicFreqEnv = {};
+AmpEnv dynamicAmpEnv = {};
+
+
+int count = 0;
+
+void setup() {
+  Serial.begin(115200);
+  vapi.init();
+
+  dynamicFreqEnv = vapi.createFreqEnv(110, 110);
+  dynamicAmpEnv = vapi.createAmpEnv(0.5, 0.0, 3, 2, 1, 3, 1.0);
+}
+
+void loop() {
+  if (!AudioLab.ready()) {
+    return;
+  }
+
+  if (count % 4 == 0) {
+    vapi.createDynamicGrain(0, SINE, dynamicFreqEnv, dynamicAmpEnv);
+  }
+
+
+  count++;
+
+  vapi.updateGrains();
+
+  AudioLab.synthesize();
+}

--- a/examples/Grains/Grains.ino
+++ b/examples/Grains/Grains.ino
@@ -74,8 +74,8 @@ void setup()
    * @param duration The number of windows the attack state will last for
    * @param curve Factor to influence the shave of the progression curve of the grain
    */
-  sweepFreqEnv = vapi.createFreqEnv(targetFreq, targetFreq, 10, 2, 3, 8, 1.0);
-  sweepAmpEnv = vapi.createAmpEnv(0.5, 0.0, 10, 2, 3, 8, 1.0);
+  sweepFreqEnv = vapi.createFreqEnv(targetFreq, targetFreq, 10, 0, 0, 8, 1.0);
+  sweepAmpEnv = vapi.createAmpEnv(0.5, 0.0, 10, 0, 0, 8, 1.0);
 }
 
 /**

--- a/examples/Grains/Grains.ino
+++ b/examples/Grains/Grains.ino
@@ -19,6 +19,7 @@
 #define MIN_AMP 0.0
 
 #define MAX_FREQ 1000
+#define START_FREQ 20
 /**
  * BACKGROUND: What is a Grain?
  * In a nutshell, grains are tiny "slices" of audio from a larger sample.
@@ -68,7 +69,7 @@ Grain* sweepGrain = vapi.createGrainArray(1, 0, SINE);
 FreqEnv sweepFreqEnv = {};
 AmpEnv sweepAmpEnv = {};
 
-float targetFreq = 100.0;
+float targetFreq = START_FREQ;
 /**
  * Runs once on ESP32 startup.
  * VibrosonicsAPI initializes AudioLab and adds modules to be managed
@@ -78,7 +79,7 @@ void setup()
 {
   Serial.begin(115200);
   vapi.init();
-  sweepFreqEnv = vapi.createFreqEnv(targetFreq, targetFreq, targetFreq, 20.0);
+  sweepFreqEnv = vapi.createFreqEnv(START_FREQ, START_FREQ, START_FREQ, 0.0);
   sweepAmpEnv = vapi.createAmpEnv(MAX_AMP, ATTACK_DURATION, MAX_AMP, DECAY_DURATION, MAX_AMP, SUSTAIN_DURATION, MIN_AMP, RELEASE_DURATION, CURVE);
 }
 
@@ -91,7 +92,7 @@ void loop()
     return;
   }
   // Outside of frequency range, reset
-  if(sweepGrain[0].getFrequency() >= MAX_FREQ) targetFreq = 100.0;
+  if(sweepGrain[0].getFrequency() >= MAX_FREQ) targetFreq = START_FREQ;
   // Previous frequency has finished playing, increase grain frequency
   if(sweepGrain[0].getGrainState() == READY){
     targetFreq = targetFreq*1.0595;

--- a/examples/Grains/Grains.ino
+++ b/examples/Grains/Grains.ino
@@ -9,6 +9,16 @@
 
 #include "VibrosonicsAPI.h"
 
+// Grain Parameters
+#define ATTACK_DURATION 10
+#define DECAY_DURATION 3
+#define SUSTAIN_DURATION 2
+#define RELEASE_DURATION 8
+#define CURVE 1.0
+#define MAX_AMP 0.5
+#define MIN_AMP 0.0
+
+#define MAX_FREQ 1000
 /**
  * BACKGROUND: What is a Grain?
  * In a nutshell, grains are tiny "slices" of audio from a larger sample.
@@ -68,14 +78,8 @@ void setup()
 {
   Serial.begin(115200);
   vapi.init();
-  /* Shape the frequency sweep grain
-   * @param grains An array of grains
-   * @param numGrains The size of a grain array
-   * @param duration The number of windows the attack state will last for
-   * @param curve Factor to influence the shave of the progression curve of the grain
-   */
-  sweepFreqEnv = vapi.createFreqEnv(targetFreq, targetFreq, 10, 3, 3, 8, 1.0);
-  sweepAmpEnv = vapi.createAmpEnv(0.5, 0.0, 2, 1, 2, 3, 1.0);
+  sweepFreqEnv = vapi.createFreqEnv(targetFreq, targetFreq);
+  sweepAmpEnv = vapi.createAmpEnv(MAX_AMP, MIN_AMP, ATTACK_DURATION, DECAY_DURATION, SUSTAIN_DURATION, RELEASE_DURATION, CURVE);
 }
 
 /**
@@ -87,7 +91,7 @@ void loop()
     return;
   }
   // Outside of frequency range, reset
-  if(sweepGrain[0].getFrequency() >= 4000) targetFreq = 100.0;
+  if(sweepGrain[0].getFrequency() >= MAX_FREQ) targetFreq = 100.0;
   // Previous frequency has finished playing, increase grain frequency
   if(sweepGrain[0].getGrainState() == READY){
     targetFreq = targetFreq*1.0595;
@@ -99,5 +103,5 @@ void loop()
   // Use AudioLab to synthesize waves for output
   AudioLab.synthesize();
   // Uncomment for debugging:
-  Serial.printf("State: %i, Frequency: %f, Amplitude: %f\n", sweepGrain[0].getGrainState(), sweepGrain[0].getFrequency(), sweepGrain[0].getAmplitude());
+  sweepGrain->printGrain();
 }

--- a/examples/Grains/Grains.ino
+++ b/examples/Grains/Grains.ino
@@ -78,8 +78,8 @@ void setup()
 {
   Serial.begin(115200);
   vapi.init();
-  sweepFreqEnv = vapi.createFreqEnv(targetFreq, targetFreq);
-  sweepAmpEnv = vapi.createAmpEnv(MAX_AMP, MIN_AMP, ATTACK_DURATION, DECAY_DURATION, SUSTAIN_DURATION, RELEASE_DURATION, CURVE);
+  sweepFreqEnv = vapi.createFreqEnv(targetFreq, targetFreq, targetFreq, 20.0);
+  sweepAmpEnv = vapi.createAmpEnv(MAX_AMP, ATTACK_DURATION, MAX_AMP, DECAY_DURATION, MAX_AMP, SUSTAIN_DURATION, MIN_AMP, RELEASE_DURATION, CURVE);
 }
 
 /**

--- a/examples/Grains/Grains.ino
+++ b/examples/Grains/Grains.ino
@@ -74,8 +74,8 @@ void setup()
    * @param duration The number of windows the attack state will last for
    * @param curve Factor to influence the shave of the progression curve of the grain
    */
-  sweepFreqEnv = vapi.createFreqEnv(targetFreq, targetFreq, 10, 0, 0, 8, 1.0);
-  sweepAmpEnv = vapi.createAmpEnv(0.5, 0.0, 10, 0, 0, 8, 1.0);
+  sweepFreqEnv = vapi.createFreqEnv(targetFreq, targetFreq, 10, 3, 3, 8, 1.0);
+  sweepAmpEnv = vapi.createAmpEnv(0.5, 0.0, 2, 1, 2, 3, 1.0);
 }
 
 /**

--- a/examples/Grains/Grains.ino
+++ b/examples/Grains/Grains.ino
@@ -55,6 +55,8 @@
 VibrosonicsAPI vapi = VibrosonicsAPI();
 
 Grain* sweepGrain = vapi.createGrainArray(1, 0, SINE);
+FreqEnv sweepFreqEnv = {};
+AmpEnv sweepAmpEnv = {};
 
 float targetFreq = 100.0;
 /**
@@ -70,16 +72,10 @@ void setup()
    * @param grains An array of grains
    * @param numGrains The size of a grain array
    * @param duration The number of windows the attack state will last for
-   * @param freqMod The multiplicative modulation factor for the frequency of the attack state
-   * @param ampMod The multiplicative modulation factor for the frequency of the attack state
    * @param curve Factor to influence the shave of the progression curve of the grain
    */
-  vapi.shapeGrainAttack(sweepGrain, 1, 10, 1.0, 1.0, 1.0);
-  vapi.shapeGrainSustain(sweepGrain, 1, 3, 1.0, 1.0);
-  vapi.shapeGrainRelease(sweepGrain, 1, 8, 1.0, 1.0, 1.0);
-  sweepGrain[0].setAttack(targetFreq, 0.5, sweepGrain[0].getAttackDuration());
-  sweepGrain[0].setSustain(targetFreq, 0.5, sweepGrain[0].getSustainDuration());
-  sweepGrain[0].setRelease(targetFreq, 0.0, sweepGrain[0].getReleaseDuration());
+  sweepFreqEnv = vapi.createFreqEnv(targetFreq, targetFreq, 10, 2, 3, 8, 1.0);
+  sweepAmpEnv = vapi.createAmpEnv(0.5, 0.0, 10, 2, 3, 8, 1.0);
 }
 
 /**
@@ -94,10 +90,9 @@ void loop()
   if(sweepGrain[0].getFrequency() >= 4000) targetFreq = 100.0;
   // Previous frequency has finished playing, increase grain frequency
   if(sweepGrain[0].getGrainState() == READY){
-    targetFreq = targetFreq*1.05;
-    sweepGrain[0].setAttack(targetFreq, 0.5, sweepGrain[0].getAttackDuration());
-    sweepGrain[0].setSustain(targetFreq, 0.5, sweepGrain[0].getSustainDuration());
-    sweepGrain[0].setRelease(targetFreq, 0.0, sweepGrain[0].getReleaseDuration());
+    targetFreq = targetFreq*1.0595;
+    sweepFreqEnv.targetFrequency = targetFreq;
+    vapi.triggerGrains(sweepGrain, 1, sweepFreqEnv, sweepAmpEnv);
   }
   // Progress the grain through its curve
   vapi.updateGrains();

--- a/examples/New_MirrorMode/New_MirrorMode.ino
+++ b/examples/New_MirrorMode/New_MirrorMode.ino
@@ -1,0 +1,97 @@
+#include "VibrosonicsAPI.h"
+
+#define NUM_BASS_PEAKS 1
+#define NUM_MID_PEAKS 2
+
+VibrosonicsAPI vapi = VibrosonicsAPI();
+
+float windowData[WINDOW_SIZE_BY_2];
+
+Spectrogram processedSpectrogram = Spectrogram(2);
+Spectrogram rawSpectrogram = Spectrogram(2);
+
+ModuleGroup modules = ModuleGroup(&processedSpectrogram);
+ModuleGroup rawModules = ModuleGroup(&rawSpectrogram);
+MajorPeaks bassPeaks = MajorPeaks(NUM_BASS_PEAKS);
+MajorPeaks midPeaks = MajorPeaks(NUM_MID_PEAKS);
+Noisiness noisiness = Noisiness();
+MeanAmplitude meanAmp = MeanAmplitude();
+PercussionDetection snareDetector = PercussionDetection(200, 150, 0.8);
+Grain* snareGrains = vapi.createGrainArray(1, 0, SINE);
+Grain* midGrains = vapi.createGrainArray(2, 0, SINE);
+Grain& snareGrain = snareGrains[0];
+
+
+void setup() {
+    Serial.begin(115200);
+    vapi.init();
+
+    modules.addModule(&bassPeaks, 20, 300);
+    modules.addModule(&midPeaks, 300, 2800);
+    modules.addModule(&meanAmp, 2000, 4000);
+
+    rawModules.addModule(&noisiness, 20, 1800);
+    rawModules.addModule(&snareDetector, 2000, 4000);
+
+    vapi.shapeGrainAttack(&snareGrain, 1, 1, 1.0, 1.0, 1.0);
+    vapi.shapeGrainSustain(&snareGrain, 1, 1, 1.0, 1.0);
+    vapi.shapeGrainRelease(&snareGrain, 1, 2, 1.0, 1.0, 1.0);
+    vapi.shapeGrainAttack(midGrains, 1, 1, 1.0, 1.0, 1.0);
+    vapi.shapeGrainSustain(midGrains, 1, 1, 1.0, 1.0);
+    vapi.shapeGrainRelease(midGrains, 1, 2, 1.0, 1.0, 1.0);
+}
+
+void loop() {
+    if (!AudioLab.ready()) {
+        return;
+    }
+
+    vapi.processAudioInput(windowData);
+    rawSpectrogram.pushWindow(windowData);
+
+    vapi.noiseFloorCFAR(windowData, WINDOW_SIZE_BY_2, 6, 1, 1.6);
+    processedSpectrogram.pushWindow(windowData);
+
+    modules.runAnalysis();
+    rawModules.runAnalysis();
+
+    synthesizePeaks(&bassPeaks, 0, NUM_BASS_PEAKS);
+
+    float** mid_data = midPeaks.getOutput();
+    vapi.mapFrequenciesLinear(mid_data[MP_FREQ], NUM_MID_PEAKS);
+
+    vapi.mapAmplitudes(mid_data[MP_AMP], NUM_MID_PEAKS, 10000);
+    for(int i = 0; i < NUM_MID_PEAKS; i++) {
+        mid_data[MP_AMP][i] *= 2;
+    }
+
+    // vapi.triggerGrains(midGrains, NUM_MID_PEAKS, mid_data);
+    vapi.assignWaves(mid_data[MP_FREQ], mid_data[MP_AMP], NUM_MID_PEAKS, 1);
+
+
+    // // snare detection and triggering
+    // if (snareDetector.getOutput() && snareGrain.getGrainState() == READY) {
+    //     float mean = meanAmp.getOutput();
+    //     vapi.mapAmplitudes(&mean, 1, 75);
+    //     float snareAmp = pow(mean, 3.0f);
+    //     snareAmp = fmin(snareAmp * 8.0f, 1.0f);
+
+    //     float snareFreq = bassPeaks.getOutput()[MP_FREQ][0] * 2.0f;
+    //     if (snareFreq < 100.0f) snareFreq *= 2.0f;
+    //     if (snareFreq == 0.0f) snareFreq = 200.0f;
+
+    //     snareGrain.setAttack(snareFreq, snareAmp, snareGrain.getAttackDuration());
+    //     snareGrain.setSustain(snareFreq, snareAmp, snareGrain.getSustainDuration());
+    //     snareGrain.setRelease(snareFreq, 0.0f, snareGrain.getReleaseDuration());
+    // }
+
+    vapi.updateGrains();
+    AudioLab.synthesize();
+    // AudioLab.printWaves(); 
+}
+
+void synthesizePeaks(MajorPeaks* peaks, int channel, int numPeaks) {
+    float** peaksData = peaks->getOutput();
+    vapi.mapAmplitudes(peaksData[MP_AMP], numPeaks, 10000);
+    vapi.assignWaves(peaksData[MP_FREQ], peaksData[MP_AMP], numPeaks, channel);
+}

--- a/examples/Percussion/Percussion.ino
+++ b/examples/Percussion/Percussion.ino
@@ -31,8 +31,8 @@ void setup() {
   percussionDetection.setDebugMode(0x01);
   modules.addModule(&percussionDetection, 1800, 4000);
 
-  dynamicFreqEnv = vapi.createFreqEnv(110, 110);
-  dynamicAmpEnv = vapi.createAmpEnv(0.5, 0.0, 1, 0, 1, 3, 1.0);
+  dynamicFreqEnv = vapi.createFreqEnv(110, 110, 110, 20);
+  dynamicAmpEnv = vapi.createAmpEnv(0.5, 1, 0.5, 2, 0.4, 1, 0.0, 3, 1.0);
 }
 
 void loop() {
@@ -69,13 +69,13 @@ void loop() {
 
   modules.runAnalysis();
 
-  Serial.printf("raw entropy: %f\n", entropy);
+  //Serial.printf("raw entropy: %f\n", entropy);
 
   if (percussionDetection.getOutput()) {
     Serial.printf("Percussion detected\n");
     vapi.createDynamicGrain(1, SINE, dynamicFreqEnv, dynamicAmpEnv);
   } else {
-    Serial.printf("---\n");
+    //Serial.printf("---\n");
   }
 
   vapi.updateGrains();

--- a/examples/Percussion/Percussion.ino
+++ b/examples/Percussion/Percussion.ino
@@ -18,7 +18,9 @@ Spectrogram percussionSpectrogram = Spectrogram(2);
 ModuleGroup modules = ModuleGroup(&rawSpectrogram);
 
 PercussionDetection percussionDetection = PercussionDetection(0.5, 1800000, 0.75);
-Grain* percussionGrain = vapi.createGrainArray(1, 0, SINE);
+
+FreqEnv dynamicFreqEnv = {};
+AmpEnv dynamicAmpEnv = {};
 
 int count = 0;
 
@@ -29,9 +31,8 @@ void setup() {
   percussionDetection.setDebugMode(0x01);
   modules.addModule(&percussionDetection, 1800, 4000);
 
-  vapi.shapeGrainAttack(percussionGrain, 1, 1, 1.0, 1.0, 1.0);
-  vapi.shapeGrainSustain(percussionGrain, 1, 1, 1.0, 1.0);
-  vapi.shapeGrainRelease(percussionGrain, 1, 3, 1.0, 1.0, 1.0);
+  dynamicFreqEnv = vapi.createFreqEnv(110, 110);
+  dynamicAmpEnv = vapi.createAmpEnv(0.5, 0.0, 1, 0, 1, 3, 1.0);
 }
 
 void loop() {
@@ -72,11 +73,7 @@ void loop() {
 
   if (percussionDetection.getOutput()) {
     Serial.printf("Percussion detected\n");
-
-    percussionGrain[0].setAttack(100, 0.5, percussionGrain[0].getAttackDuration());
-    percussionGrain[0].setSustain(100, 0.5, percussionGrain[0].getSustainDuration());
-    percussionGrain[0].setRelease(100, 0.0, percussionGrain[0].getReleaseDuration());
-    percussionGrain[0].transitionTo(ATTACK);
+    vapi.createDynamicGrain(1, SINE, dynamicFreqEnv, dynamicAmpEnv);
   } else {
     Serial.printf("---\n");
   }

--- a/examples/Percussion/Percussion.ino
+++ b/examples/Percussion/Percussion.ino
@@ -1,0 +1,87 @@
+/**
+ * @file Percussion.ino
+ *
+ * This example shows how to detect percussion.
+ */
+
+#include "VibrosonicsAPI.h"
+
+VibrosonicsAPI vapi = VibrosonicsAPI();
+
+float windowData[WINDOW_SIZE_BY_2];
+float filteredData[WINDOW_SIZE_BY_2] = { 0 };
+float smoothedData[WINDOW_SIZE_BY_2] = { 0 };
+
+Spectrogram rawSpectrogram = Spectrogram(2);
+Spectrogram percussionSpectrogram = Spectrogram(2);
+
+ModuleGroup modules = ModuleGroup(&rawSpectrogram);
+
+PercussionDetection percussionDetection = PercussionDetection(0.5, 1800000, 0.75);
+Grain* percussionGrain = vapi.createGrainArray(1, 0, SINE);
+
+int count = 0;
+
+void setup() {
+  Serial.begin(115200);
+  vapi.init();
+
+  percussionDetection.setDebugMode(0x01);
+  modules.addModule(&percussionDetection, 1800, 4000);
+
+  vapi.shapeGrainAttack(percussionGrain, 1, 1, 1.0, 1.0, 1.0);
+  vapi.shapeGrainSustain(percussionGrain, 1, 1, 1.0, 1.0);
+  vapi.shapeGrainRelease(percussionGrain, 1, 3, 1.0, 1.0, 1.0);
+}
+
+void loop() {
+  if (!AudioLab.ready()) {
+    return;
+  }
+
+  vapi.processAudioInput(windowData);
+
+  // floor most noise
+  vapi.noiseFloor(windowData, WINDOW_SIZE_BY_2, 300);
+
+  // calculate the entropy of the raw audio data
+  float entropy = AudioPrism::entropy(windowData, 0, WINDOW_SIZE_BY_2);
+
+  // copy the windowData to filterdData
+  memcpy(filteredData, windowData, WINDOW_SIZE_BY_2);
+
+  // apply CFAR to clean up the data
+  vapi.noiseFloorCFAR(filteredData, WINDOW_SIZE_BY_2, 6, 1, 1.4);
+
+  // smooth over a long period of time to capture melodic elements
+  AudioPrism::smooth_window_over_time(filteredData, smoothedData, 0.2);
+
+  // subtract the melodic data from the raw data to capture the 'percussive data'
+  for (int i = 0; i < WINDOW_SIZE_BY_2; i++) {
+    windowData[i] = windowData[i] - smoothedData[i];
+    if (windowData[i] < 0) {
+      windowData[i] = 0;
+    }
+  }
+
+  rawSpectrogram.pushWindow(windowData);
+
+  modules.runAnalysis();
+
+  Serial.printf("raw entropy: %f\n", entropy);
+
+  if (percussionDetection.getOutput()) {
+    Serial.printf("Percussion detected\n");
+
+    percussionGrain[0].setAttack(100, 0.5, percussionGrain[0].getAttackDuration());
+    percussionGrain[0].setSustain(100, 0.5, percussionGrain[0].getSustainDuration());
+    percussionGrain[0].setRelease(100, 0.0, percussionGrain[0].getReleaseDuration());
+    percussionGrain[0].transitionTo(ATTACK);
+  } else {
+    Serial.printf("---\n");
+  }
+
+  vapi.updateGrains();
+
+  AudioLab.synthesize();
+}

--- a/examples/mirrorMode/mirrorMode.ino
+++ b/examples/mirrorMode/mirrorMode.ino
@@ -19,7 +19,9 @@ MajorPeaks majorPeaks = MajorPeaks(NUM_PEAKS);
 Spectrogram percussiveSpectrogram = Spectrogram(2);
 ModuleGroup percussive = ModuleGroup(&percussiveSpectrogram);
 PercussionDetection percussionDetection = PercussionDetection();
-Grain* percussionGrain = vapi.createGrainArray(1, 0, SINE);
+
+FreqEnv dynamicFreqEnv = {};
+AmpEnv dynamicAmpEnv = {};
 
 void setup() {
   Serial.begin(115200);
@@ -30,9 +32,8 @@ void setup() {
   melodic.addModule(&majorPeaks, 220, 1400);
   percussive.addModule(&percussionDetection, 1800, 4000);
 
-  vapi.shapeGrainAttack(percussionGrain, 1, 1, 1.0, 1.0, 1.0);
-  vapi.shapeGrainSustain(percussionGrain, 1, 1, 1.0, 1.0);
-  vapi.shapeGrainRelease(percussionGrain, 1, 3, 1.0, 1.0, 1.0);
+  dynamicFreqEnv = vapi.createFreqEnv(110, 110);
+  dynamicAmpEnv = vapi.createAmpEnv(0.5, 0.0, 3, 2, 1, 3, 1.0);
 }
 
 void loop() {
@@ -83,11 +84,7 @@ void loop() {
 
   if (percussionDetection.getOutput()) {
     Serial.printf("Percussion detected\n");
-
-    percussionGrain[0].setAttack(110, 0.8, percussionGrain[0].getAttackDuration());
-    percussionGrain[0].setSustain(110, 0.8, percussionGrain[0].getSustainDuration());
-    percussionGrain[0].setRelease(110, 0.0, percussionGrain[0].getReleaseDuration());
-    percussionGrain[0].transitionTo(ATTACK);
+    vapi.createDynamicGrain(1, SINE, dynamicFreqEnv, dynamicAmpEnv);
   } else {
     Serial.printf("\n");
   }

--- a/examples/mirrorMode/mirrorMode.ino
+++ b/examples/mirrorMode/mirrorMode.ino
@@ -32,8 +32,8 @@ void setup() {
   melodic.addModule(&majorPeaks, 220, 1400);
   percussive.addModule(&percussionDetection, 1800, 4000);
 
-  dynamicFreqEnv = vapi.createFreqEnv(110, 110);
-  dynamicAmpEnv = vapi.createAmpEnv(0.5, 0.0, 3, 2, 1, 3, 1.0);
+  dynamicFreqEnv = vapi.createFreqEnv(110, 110, 110, 20);
+  dynamicAmpEnv = vapi.createAmpEnv(0.5, 3, 0.5, 2, 0.4, 1, 0.0, 3, 1.0);
 }
 
 void loop() {

--- a/examples/mirrorMode/mirrorMode.ino
+++ b/examples/mirrorMode/mirrorMode.ino
@@ -1,16 +1,25 @@
 #include "VibrosonicsAPI.h"
 
 // set a number of peaks for the major peaks module to find
-#define NUM_PEAKS 4
+#define NUM_PEAKS 2
 
 VibrosonicsAPI vapi = VibrosonicsAPI();
 
-float windowData[WINDOW_SIZE_BY_2];
-Spectrogram rawSpectrogram = Spectrogram(2);
-Spectrogram processedSpectrogram = Spectrogram(2);
+float windowData[WINDOW_SIZE_BY_2] = { 0 };
+float filteredData[WINDOW_SIZE_BY_2] = { 0 };
+float longSmoothedData[WINDOW_SIZE_BY_2] = { 0 };
+float shortSmoothedData[WINDOW_SIZE_BY_2] = { 0 };
 
-ModuleGroup modules = ModuleGroup(&processedSpectrogram);
+Spectrogram rawSpectrogram(1);
+
+Spectrogram processedSpectrogram = Spectrogram(2);
+ModuleGroup melodic = ModuleGroup(&processedSpectrogram);
 MajorPeaks majorPeaks = MajorPeaks(NUM_PEAKS);
+
+Spectrogram percussiveSpectrogram = Spectrogram(2);
+ModuleGroup percussive = ModuleGroup(&percussiveSpectrogram);
+PercussionDetection percussionDetection = PercussionDetection();
+Grain* percussionGrain = vapi.createGrainArray(1, 0, SINE);
 
 void setup() {
   Serial.begin(115200);
@@ -18,8 +27,12 @@ void setup() {
   // call the API setup function
   vapi.init();
 
-  // add the major peaks analysis module
-  modules.addModule(&majorPeaks, 20, 3000);
+  melodic.addModule(&majorPeaks, 220, 1400);
+  percussive.addModule(&percussionDetection, 1800, 4000);
+
+  vapi.shapeGrainAttack(percussionGrain, 1, 1, 1.0, 1.0, 1.0);
+  vapi.shapeGrainSustain(percussionGrain, 1, 1, 1.0, 1.0);
+  vapi.shapeGrainRelease(percussionGrain, 1, 3, 1.0, 1.0, 1.0);
 }
 
 void loop() {
@@ -30,17 +43,57 @@ void loop() {
 
   // process the raw audio signal into frequency domain data
   vapi.processAudioInput(windowData);
-  rawSpectrogram.pushWindow(windowData);
 
   // process the freqeuncy domain data
-  vapi.noiseFloorCFAR(windowData, WINDOW_SIZE_BY_2, 6, 2, 1.4);
-  processedSpectrogram.pushWindow(windowData);
+  vapi.noiseFloor(windowData, WINDOW_SIZE_BY_2, 220);
+  
+  // save the raw data for synthesis
+  rawSpectrogram.pushWindow(windowData);
+
+  // copy the windowData to filterdData
+  memcpy(filteredData, windowData, WINDOW_SIZE_BY_2);
+
+  // apply CFAR to filter the data
+  vapi.noiseFloorCFAR(filteredData, WINDOW_SIZE_BY_2, 6, 1, 1.4);
+
+  // smooth the filtered data over a long and short period of time
+  AudioPrism::smooth_window_over_time(filteredData, longSmoothedData, 0.2);
+  AudioPrism::smooth_window_over_time(filteredData, shortSmoothedData, 0.8);
+
+  // push the short smoothed data for the melodic peak detection
+  processedSpectrogram.pushWindow(shortSmoothedData);
+
+  // subtract the long smoothed melodic data from the raw data to capture the
+  // 'percussive data'
+  for (int i = 0; i < WINDOW_SIZE_BY_2; i++) {
+    windowData[i] = windowData[i] - longSmoothedData[i];
+    if (windowData[i] < 0) {
+      windowData[i] = 0;
+    }
+  }
+
+  percussiveSpectrogram.pushWindow(windowData);
 
   // have analysis modules analyze the frequency domain data
-  modules.runAnalysis();
+  melodic.runAnalysis();
+  percussive.runAnalysis();
 
   // create audio waves according the the output of the major peaks module
-  synthesizePeaks(&majorPeaks);
+  synthesizePeaks(&majorPeaks, percussionDetection.getOutput());
+
+  if (percussionDetection.getOutput()) {
+    Serial.printf("Percussion detected\n");
+
+    percussionGrain[0].setAttack(110, 0.8, percussionGrain[0].getAttackDuration());
+    percussionGrain[0].setSustain(110, 0.8, percussionGrain[0].getSustainDuration());
+    percussionGrain[0].setRelease(110, 0.0, percussionGrain[0].getReleaseDuration());
+    percussionGrain[0].transitionTo(ATTACK);
+  } else {
+    Serial.printf("\n");
+  }
+
+  // update the percussion grain
+  vapi.updateGrains();
 
   // synthesize the waves created
   AudioLab.synthesize();
@@ -48,11 +101,37 @@ void loop() {
   //AudioLab.printWaves();
 }
 
+int interpolateAroundPeak(float* data, int indexOfPeak, int sampleRate, int windowSize) {
+  float _freqRes = sampleRate * 1.0 / windowSize;
+  float prePeak = indexOfPeak == 0 ? 0.0 : data[indexOfPeak - 1];
+  float atPeak = data[indexOfPeak];
+  float postPeak = indexOfPeak == WINDOW_SIZE_BY_2 ? 0.0 : data[indexOfPeak + 1];
+  // summing around the index of maximum amplitude to normalize magnitudeOfChange
+  float peakSum = prePeak + atPeak + postPeak;
+  // interpolating the direction and magnitude of change, and normalizing from -1.0 to 1.0
+  float magnitudeOfChange = ((atPeak + postPeak) - (atPeak + prePeak)) / (peakSum > 0.0 ? peakSum : 1.0);
+
+  // return interpolated frequency
+  return int(round((float(indexOfPeak) + magnitudeOfChange) * _freqRes));
+}
+
 // synthesizing should generally take from raw spectrum
-void synthesizePeaks(MajorPeaks* peaks) {
+//
+// *this should not be copied as a standard function, is specialized for prax
+// demo
+void synthesizePeaks(MajorPeaks* peaks, int percussion) {
   float** peaksData = peaks->getOutput();
   // interpolate around peaks
-  vapi.mapAmplitudes(peaksData[MP_AMP], NUM_PEAKS);
-  vapi.assignWaves(peaksData[MP_FREQ], peaksData[MP_AMP], NUM_PEAKS, 0);
-  vapi.assignWaves(peaksData[MP_FREQ], peaksData[MP_AMP], NUM_PEAKS, 1);
+  vapi.mapFrequenciesLinear(peaksData[MP_FREQ], NUM_PEAKS);
+  vapi.mapAmplitudes(peaksData[MP_AMP], NUM_PEAKS, 10000);
+  for (int i = 0; i < NUM_PEAKS; i++) {
+    int freq = interpolateAroundPeak(rawSpectrogram.getCurrentWindow(), round(int(peaksData[MP_FREQ][i] * FREQ_WIDTH)), SAMPLE_RATE, WINDOW_SIZE);
+    if (i == 0) {
+      vapi.assignWave(freq, peaksData[MP_AMP][i], 1);
+    } else if (percussion) {
+      // vapi.assignWave(freq, peaksData[MP_AMP][i] / 2, 0);
+    } else {
+      // vapi.assignWave(freq, peaksData[MP_AMP][i], 0);
+    }
+  }
 }

--- a/examples/mirrorMode2/mirrorMode2.ino
+++ b/examples/mirrorMode2/mirrorMode2.ino
@@ -43,18 +43,18 @@ void loop() {
   //AudioLab.printWaves();
 }
 
-int interpolateAroundPeak(float *data, int indexOfPeak, int sampleRate, int windowSize) {
-    float _freqRes = sampleRate * 1.0 / windowSize;
-    float prePeak = indexOfPeak == 0 ? 0.0 : data[indexOfPeak - 1];
-    float atPeak = data[indexOfPeak];
-    float postPeak = indexOfPeak == WINDOW_SIZE_BY_2 ? 0.0 : data[indexOfPeak + 1];
-    // summing around the index of maximum amplitude to normalize magnitudeOfChange
-    float peakSum = prePeak + atPeak + postPeak;
-    // interpolating the direction and magnitude of change, and normalizing from -1.0 to 1.0
-    float magnitudeOfChange = ((atPeak + postPeak) - (atPeak + prePeak)) / (peakSum > 0.0 ? peakSum : 1.0);
+int interpolateAroundPeak(float* data, int indexOfPeak, int sampleRate, int windowSize) {
+  float _freqRes = sampleRate * 1.0 / windowSize;
+  float prePeak = indexOfPeak == 0 ? 0.0 : data[indexOfPeak - 1];
+  float atPeak = data[indexOfPeak];
+  float postPeak = indexOfPeak == WINDOW_SIZE_BY_2 ? 0.0 : data[indexOfPeak + 1];
+  // summing around the index of maximum amplitude to normalize magnitudeOfChange
+  float peakSum = prePeak + atPeak + postPeak;
+  // interpolating the direction and magnitude of change, and normalizing from -1.0 to 1.0
+  float magnitudeOfChange = ((atPeak + postPeak) - (atPeak + prePeak)) / (peakSum > 0.0 ? peakSum : 1.0);
 
-    // return interpolated frequency
-    return int(round((float(indexOfPeak) + magnitudeOfChange) * _freqRes));
+  // return interpolated frequency
+  return int(round((float(indexOfPeak) + magnitudeOfChange) * _freqRes));
 }
 
 // synthesizing should generally take from raw spectrum
@@ -69,3 +69,29 @@ void synthesizePeaks(MajorPeaks* peaks) {
     vapi.assignWave(freq, peaksData[MP_AMP][i], 1);
   }
 }
+
+
+
+
+    
+
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+ 
+

--- a/src/Grain.cpp
+++ b/src/Grain.cpp
@@ -334,10 +334,10 @@ int Grain::getReleaseDuration()
  */
 void Grain::setFreqEnv(FreqEnv freqEnv)
 {
-  attack.frequency = freqEnv.targetFrequency;
-  decay.frequency = freqEnv.targetFrequency;
-  sustain.frequency = freqEnv.targetFrequency;
-  release.frequency = freqEnv.minFrequency;
+  attack.frequency = freqEnv.attackFrequency;
+  decay.frequency = freqEnv.decayFrequency;
+  sustain.frequency = freqEnv.sustainFrequency;
+  release.frequency = freqEnv.releaseFrequency;
 }
 
 /**
@@ -347,16 +347,15 @@ void Grain::setFreqEnv(FreqEnv freqEnv)
  */
 void Grain::setAmpEnv(AmpEnv ampEnv)
 {
-  attack.amplitude = ampEnv.targetAmplitude;
+  attack.amplitude = ampEnv.attackAmplitude;
   attack.duration = ampEnv.attackDuration;
   attack.curve = ampEnv.curve;
-  decay.amplitude = ampEnv.targetAmplitude;
+  decay.amplitude = ampEnv.decayAmplitude;
   decay.duration = ampEnv.decayDuration;
   decay.curve = ampEnv.curve;
-  sustain.amplitude = ampEnv.targetAmplitude * .8;
+  sustain.amplitude = ampEnv.sustainAmplitude;
   sustain.duration = ampEnv.sustainDuration;
-  sustain.curve = ampEnv.curve;
-  release.amplitude = ampEnv.minAmplitude;
+  release.amplitude = ampEnv.releaseAmplitude;
   release.duration = ampEnv.releaseDuration;
   release.curve = ampEnv.curve;
 }

--- a/src/Grain.h
+++ b/src/Grain.h
@@ -26,14 +26,20 @@ enum grainState {
  *
  * Struct containing target frequency data for a grain
  *
- * @var FreqEnv::targetFrequency
- * The maximum frequency the grain will reach in it's lifetime.
- * @var FreqEnv::minFrequency
- * The minimum frequency the grain will reach in it's lifetime.
+ * @var FreqEnv::attackFrequency
+ * The maximum frequency the grain will reach in its attack state.
+ * @var FreqEnv::decayFrequency
+ * The maximum frequency the grain will reach in its decay state.
+ * @var FreqEnv::sustainFrequency
+ * The frequency the grain will output in its sustain state.
+ * @var FreqEnv::releaseFrequency
+ * The lowest frequency the grain will output in its release state.
  */
 struct FreqEnv {
-  float targetFrequency = 100.0;
-  float minFrequency = 0.0;
+  float attackFrequency = 100.0;
+  float decayFrequency = 100.0;
+  float sustainFrequency = 100.0;
+  float releaseFrequency = 100.0;
 };
 
 /**
@@ -42,27 +48,33 @@ struct FreqEnv {
  * Struct containing target amplitude data for a grain, its state
  * duration parameters, and the curve shape.
  *
- * @var AmpEnv::targetAmplitude
- * The maximum amplitude the grain will reach in it's lifetime.
- * @var AmpEnv::minAmplitude
- * The minimum amplitude the grain will reach in it's lifetime.
+ * @var AmpEnv::attackAmplitude
+ * The maximum amplitude the grain will reach in its attack state.
  * @var AmpEnv::attackDuration
  * The number of windows the attack state will run for.
+ * @var AmpEnv::decayAmplitude
+ * The maximum amplitude the grain will reach in its decay state.
  * @var AmpEnv::decayDuration
  * The number of windows the decay state will run for.
+ * @var AmpEnv::sustainAmplitude
+ * The amplitude the grain will output in its sustain state.
  * @var AmpEnv::sustainDuration
  * The number of windows the sustain state will run for.
+ * @var AmpEnv::releaseAmplitude
+ * The minimum amplitude the grain will reach in its release state.
  * @var AmpEnv::releaseDuration
  * The number of windows the release state will run for.
  * @var AmpEnv::curve
  * The shape of the progression through the ADSR curve.
  */
 struct AmpEnv {
-  float targetAmplitude = 0.5;
-  float minAmplitude = 0.0;
+  float attackAmplitude = 0.5;
   int attackDuration = 1;
+  float decayAmplitude = 0.5;
   int decayDuration = 1;
+  float sustainAmplitude = 0.5;
   int sustainDuration = 1;
+  float releaseAmplitude = 0.0;
   int releaseDuration = 1;
   float curve = 1.0f;
 };

--- a/src/Grain.h
+++ b/src/Grain.h
@@ -16,8 +16,29 @@
 enum grainState {
   READY,
   ATTACK,
+  DECAY,
   SUSTAIN,
   RELEASE
+};
+
+struct FreqEnv {
+  float targetFrequency = 100.0;
+  float minFrequency = 0.0;
+  int attackDuration = 1;
+  int decayDuration = 1;
+  int sustainDuration = 1;
+  int releaseDuration = 1;
+  float curve = 1.0f;
+};
+
+struct AmpEnv {
+  float targetAmplitude = 0.5;
+  float minAmplitude = 0.0;
+  int attackDuration = 1;
+  int decayDuration = 1;
+  int sustainDuration = 1;
+  int releaseDuration = 1;
+  float curve = 1.0f;
 };
 
 class GrainList;
@@ -45,17 +66,14 @@ private:
     float frequency = 0.0f;
     //! Targeted amplitude for the phase
     float amplitude = 0.0f;
-    //! Modulates frequency by multiplying frequencyModulator to frequency
-    float frequencyModulator = 1.0f; // Default: no modulation
-    //! Modulates amplitude by multiplying amplitudeModulator to amplitude
-    float amplitudeModulator = 1.0f; // Default: no modulation
-
     //! Shapes the curve by raising curveStep*windowCounter to the degree of the curve value
     float curve = 1.0f; // Default: linear
   };
 
   //! Struct containing attack parameters
   Phase attack;
+  //! Struct containing decay parameters
+  Phase decay;
   //! Struct containing sustain parameters
   Phase sustain;
   //! Struct containing release parameters
@@ -85,11 +103,6 @@ private:
 
   //! Update frequency and amplitude values based on current grain state.
   void run();
-
-  //! Helper function to perform necessary operations on grain parameters
-  //! when transitioning between run states
-  void transitionTo(grainState newState);
-
 public:
   //! Default constructor to allocate a new grain
   Grain();
@@ -100,6 +113,9 @@ public:
 
   //! Updates grain parameters in the attack state
   void setAttack(float frequency, float amplitude, int duration);
+
+  //! Updates grain parameters in the decay state
+  void setDecay(float frequency, float amplitude, int duration);
 
   //! Updates grain parameters in the sustain state
   void setSustain(float frequency, float amplitude, int duration);
@@ -113,11 +129,15 @@ public:
   //! Sets grain wave type (SINE, COSINE, SQUARE, TRIANGLE, SAWTOOTH)
   void setWaveType(WaveType waveType);
 
-  //! Returns the state of a grain (READY, ATTACK, SUSTAIN, RELEASE)
+  //! Returns the state of a grain (READY, ATTACK, DECAY, SUSTAIN, RELEASE)
   grainState getGrainState();
 
   //! Updates grain values and state if necessary
   static void update(GrainList *globalGrainList);
+
+  //! Helper function to perform necessary operations on grain parameters
+  //! when transitioning between run states
+  void transitionTo(grainState newState);
 
   //! Returns the current amplitude of the grain
   float getAmplitude();
@@ -128,20 +148,27 @@ public:
   //! Returns the attack duration
   int getAttackDuration();
 
+  //! Returns the decay duration
+  int getDecayDuration();
+
   //! Returns the sustain duration
   int getSustainDuration();
 
   //! Returns the release duration
   int getReleaseDuration();
 
-  //! Sets parameters for the attack state
-  void shapeAttack(int duration, float freqMod, float ampMod, float curve);
+  //! Sets grain parameters for the frequency envelope
+  void setFreqEnv(FreqEnv freqEnv);
 
-  //! Sets parameters for the sustain state
-  void shapeSustain(int duration, float freqMod, float ampMod);
+  //! Sets grain parameters for the amplitude envelope
+  void setAmpEnv(AmpEnv ampEnv);
 
-  //! Sets parameters for the release state
-  void shapeRelease(int duration, float freqMod, float ampMod, float curve);
+  //! Returns the frequncy envelope struct containing state data
+  FreqEnv getFreqEnv();
+
+  //! Returns the amplitude envelope struct containing state data
+  AmpEnv getAmpEnv();
+
 };
 
 /**
@@ -175,5 +202,4 @@ public:
   //! Returns the head of the list.
   GrainNode* getHead();
 };
-
 #endif

--- a/src/Grain.h
+++ b/src/Grain.h
@@ -21,16 +21,42 @@ enum grainState {
   RELEASE
 };
 
+/**
+ * @struct FreqEnv
+ *
+ * Struct containing target frequency data for a grain
+ *
+ * @var FreqEnv::targetFrequency
+ * The maximum frequency the grain will reach in it's lifetime.
+ * @var FreqEnv::minFrequency
+ * The minimum frequency the grain will reach in it's lifetime.
+ */
 struct FreqEnv {
   float targetFrequency = 100.0;
   float minFrequency = 0.0;
-  int attackDuration = 1;
-  int decayDuration = 1;
-  int sustainDuration = 1;
-  int releaseDuration = 1;
-  float curve = 1.0f;
 };
 
+/**
+ * @struct AmpEnv
+ *
+ * Struct containing target amplitude data for a grain, its state
+ * duration parameters, and the curve shape.
+ *
+ * @var AmpEnv::targetAmplitude
+ * The maximum amplitude the grain will reach in it's lifetime.
+ * @var AmpEnv::minAmplitude
+ * The minimum amplitude the grain will reach in it's lifetime.
+ * @var AmpEnv::attackDuration
+ * The number of windows the attack state will run for.
+ * @var AmpEnv::decayDuration
+ * The number of windows the decay state will run for.
+ * @var AmpEnv::sustainDuration
+ * The number of windows the sustain state will run for.
+ * @var AmpEnv::releaseDuration
+ * The number of windows the release state will run for.
+ * @var AmpEnv::curve
+ * The shape of the progression through the ADSR curve.
+ */
 struct AmpEnv {
   float targetAmplitude = 0.5;
   float minAmplitude = 0.0;
@@ -78,11 +104,6 @@ private:
   Phase sustain;
   //! Struct containing release parameters
   Phase release;
-
-  //! The difference in frequency between sustain and attack
-  float sustainAttackFrequencyDifference;
-  //! The difference in frequency between release and sustain
-  float releaseSustainFrequencyDifference;
 
   //! The counter for how many windows a state has run for
   int windowCounter;

--- a/src/Grain.h
+++ b/src/Grain.h
@@ -44,9 +44,9 @@ struct AmpEnv {
 class GrainList;
 
 /**
-  * This class creates and manages the Ready, Attack, Sustain,
+  * This class creates and manages the Ready, Attack, Decay, Sustain,
   * and Release states for individual grains. A grain is a very
-  * small segment of an audio segment, allowing for more granular
+  * small segment of an audio sample, allowing for more granular
   * synthesis and management of the waves that are outputted
   * through VibroSonics hardware.
   *
@@ -104,6 +104,11 @@ private:
   //! Update frequency and amplitude values based on current grain state.
   void run();
 public:
+  //! Flag to check if a grain is dynamic or static.
+  bool isDynamic;
+  //! Flag to check if a dynamic grain has finished triggering.
+  bool markedForDeletion;
+
   //! Default constructor to allocate a new grain
   Grain();
 
@@ -131,9 +136,6 @@ public:
 
   //! Returns the state of a grain (READY, ATTACK, DECAY, SUSTAIN, RELEASE)
   grainState getGrainState();
-
-  //! Updates grain values and state if necessary
-  static void update(GrainList *globalGrainList);
 
   //! Helper function to perform necessary operations on grain parameters
   //! when transitioning between run states
@@ -169,6 +171,10 @@ public:
   //! Returns the amplitude envelope struct containing state data
   AmpEnv getAmpEnv();
 
+  //! For debugging: Prints a grain's state, frequency, and amplitude.
+  void printGrain();
+
+  friend class GrainList;
 };
 
 /**
@@ -201,5 +207,7 @@ public:
   void clearList();
   //! Returns the head of the list.
   GrainNode* getHead();
+  //! Updates grains and deletes finished dynamic grains.
+  void updateAndReap();
 };
 #endif

--- a/src/VibrosonicsAPI.cpp
+++ b/src/VibrosonicsAPI.cpp
@@ -361,26 +361,26 @@ void VibrosonicsAPI::triggerGrains(Grain* grains, int numGrains, struct FreqEnv 
     }
 }
 
-FreqEnv createFreqEnv(float targetFreq, float minFreq, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve)
+FreqEnv VibrosonicsAPI::createFreqEnv(float targetFreq, float minFreq, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve)
 {
     FreqEnv newFreqEnv = {targetFreq, minFreq, attackDuration, decayDuration, sustainDuration, releaseDuration, curve};
     return newFreqEnv;
 }
 
-AmpEnv createAmpEnv(float targetAmp, float minAmp, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve)
+AmpEnv VibrosonicsAPI::createAmpEnv(float targetAmp, float minAmp, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve)
 {
     AmpEnv newAmpEnv = {targetAmp, minAmp, attackDuration, decayDuration, sustainDuration, releaseDuration, curve};
     return newAmpEnv;
 }
 
-void setGrainFreqEnv(Grain* grains, int numGrains, FreqEnv freqEnv)
+void VibrosonicsAPI::setGrainFreqEnv(Grain* grains, int numGrains, FreqEnv freqEnv)
 {
     for(int i = 0; i < numGrains; i++) {
         grains[i].setFreqEnv(freqEnv);
     }
 }
 
-void setGrainAmpEnv(Grain* grains, int numGrains, AmpEnv ampEnv)
+void VibrosonicsAPI::setGrainAmpEnv(Grain* grains, int numGrains, AmpEnv ampEnv)
 {
     for(int i = 0; i < numGrains; i++) {
         grains[i].setAmpEnv(ampEnv);

--- a/src/VibrosonicsAPI.cpp
+++ b/src/VibrosonicsAPI.cpp
@@ -349,6 +349,7 @@ Grain* VibrosonicsAPI::createDynamicGrain(uint8_t channel, WaveType waveType, Fr
 
 /**
  * Calls update for every grain in the grain list
+ * Deletes dynamic grains as needed.
  */
 void VibrosonicsAPI::updateGrains()
 {
@@ -375,18 +376,43 @@ void VibrosonicsAPI::triggerGrains(Grain* grains, int numGrains, struct FreqEnv 
     }
 }
 
-FreqEnv VibrosonicsAPI::createFreqEnv(float targetFreq, float minFreq, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve)
+/**
+ * Creates a frequency envelope struct to shape the grain's frequency parameters with
+ *
+ * @param targetFreq The maximum frequency the grain will target
+ * @param minFreq The minimum frequency the grain will target
+ */
+FreqEnv VibrosonicsAPI::createFreqEnv(float targetFreq, float minFreq)
 {
-    FreqEnv newFreqEnv = {targetFreq, minFreq, attackDuration, decayDuration, sustainDuration, releaseDuration, curve};
+    FreqEnv newFreqEnv = {targetFreq, minFreq};
     return newFreqEnv;
 }
 
+/**
+ * Creates a frequency envelope struct to shape the grain's amplitude parameters with
+ * Also sets state durations and curve shape.
+ *
+ * @param targetAmp The maximum amplitude the grain will target
+ * @param minAmp The minimum amplitude the grain will target
+ * @param attackDuration The number of windows the attack phase will last for
+ * @param decayDuration The number of windows the decay phase will last for
+ * @param sustainDuration The number of windows the sustain phase will last for
+ * @param releaseDuration The number of windows the release phase will last for
+ * @param curve The shape of the grain's progression through targeted amplitudes and frequencies
+ */
 AmpEnv VibrosonicsAPI::createAmpEnv(float targetAmp, float minAmp, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve)
 {
     AmpEnv newAmpEnv = {targetAmp, minAmp, attackDuration, decayDuration, sustainDuration, releaseDuration, curve};
     return newAmpEnv;
 }
 
+/**
+ * Sets the frequency envelope for an array of grains
+ *
+ * @param grains An array of grains to have their frequency envelope set.
+ * @param numGrains The size of the Grain array.
+ * @param freqEnv The struct containing the new frequency envelope data
+ */
 void VibrosonicsAPI::setGrainFreqEnv(Grain* grains, int numGrains, FreqEnv freqEnv)
 {
     for(int i = 0; i < numGrains; i++) {
@@ -394,6 +420,13 @@ void VibrosonicsAPI::setGrainFreqEnv(Grain* grains, int numGrains, FreqEnv freqE
     }
 }
 
+/**
+ * Sets the amplitude envelope for an array of grains
+ *
+ * @param grains An array of grains to have their amplitude envelope set.
+ * @param numGrains The size of the Grain array.
+ * @param freqEnv The struct containing the new amplitude envelope data
+ */
 void VibrosonicsAPI::setGrainAmpEnv(Grain* grains, int numGrains, AmpEnv ampEnv)
 {
     for(int i = 0; i < numGrains; i++) {

--- a/src/VibrosonicsAPI.cpp
+++ b/src/VibrosonicsAPI.cpp
@@ -384,12 +384,14 @@ void VibrosonicsAPI::triggerGrains(Grain* grains, int numGrains, struct FreqEnv 
 /**
  * Creates a frequency envelope struct to shape the grain's frequency parameters with
  *
- * @param targetFreq The maximum frequency the grain will target
- * @param minFreq The minimum frequency the grain will target
+ * @param attackFreq The frequency the grain will target in its attack state
+ * @param decayFreq The frequency the grain will target in its decay state
+ * @param sustainFreq The frequency the grain will target in its sustain state
+ * @param releaseFreq The frequency the grain will target in its release state
  */
-FreqEnv VibrosonicsAPI::createFreqEnv(float targetFreq, float minFreq)
+FreqEnv VibrosonicsAPI::createFreqEnv(float attackFreq, float decayFreq, float sustainFreq, float releaseFreq)
 {
-    FreqEnv newFreqEnv = {targetFreq, minFreq};
+    FreqEnv newFreqEnv = {attackFreq, decayFreq, sustainFreq, releaseFreq};
     return newFreqEnv;
 }
 
@@ -397,17 +399,19 @@ FreqEnv VibrosonicsAPI::createFreqEnv(float targetFreq, float minFreq)
  * Creates a frequency envelope struct to shape the grain's amplitude parameters with
  * Also sets state durations and curve shape.
  *
- * @param targetAmp The maximum amplitude the grain will target
- * @param minAmp The minimum amplitude the grain will target
+ * @param attackAmp The amplitude the grain will target in its attack state
  * @param attackDuration The number of windows the attack phase will last for
+ * @param decayAmp The amplitude the grain will target in its decay state
  * @param decayDuration The number of windows the decay phase will last for
+ * @param sustainAmp The amplitude the grain will target in its sustain state
  * @param sustainDuration The number of windows the sustain phase will last for
+ * @param releaseAmp The amplitude the grain will target in its release state
  * @param releaseDuration The number of windows the release phase will last for
  * @param curve The shape of the grain's progression through targeted amplitudes and frequencies
  */
-AmpEnv VibrosonicsAPI::createAmpEnv(float targetAmp, float minAmp, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve)
+AmpEnv VibrosonicsAPI::createAmpEnv(float attackAmp, int attackDuration, float decayAmp, int decayDuration, float sustainAmp, int sustainDuration, float releaseAmp, int releaseDuration, float curve)
 {
-    AmpEnv newAmpEnv = {targetAmp, minAmp, attackDuration, decayDuration, sustainDuration, releaseDuration, curve};
+    AmpEnv newAmpEnv = {attackAmp, attackDuration, decayAmp, decayDuration, sustainAmp, sustainDuration, releaseAmp, releaseDuration, curve};
     return newAmpEnv;
 }
 

--- a/src/VibrosonicsAPI.cpp
+++ b/src/VibrosonicsAPI.cpp
@@ -334,7 +334,12 @@ Grain* VibrosonicsAPI::createGrainArray(int numGrains, uint8_t channel, WaveType
 }
 
 /**
- * TODO: add documentation
+ * Creates a grain that runs once and is then deleted.
+ *
+ * @param channel The physical speaker channel, on current hardware valid inputs are 0-2
+ * @param waveType The type of wave Audiolab will generate utilizing the grains.
+ * @param FreqEnv The frequency data used to shape the grain.
+ * @param AmpEnv The amplitude data, duration lengths, and curve used to shape the grain.
  */
 Grain* VibrosonicsAPI::createDynamicGrain(uint8_t channel, WaveType waveType, FreqEnv freqEnv, AmpEnv ampEnv)
 {

--- a/src/VibrosonicsAPI.cpp
+++ b/src/VibrosonicsAPI.cpp
@@ -334,11 +334,25 @@ Grain* VibrosonicsAPI::createGrainArray(int numGrains, uint8_t channel, WaveType
 }
 
 /**
+ * TODO: add documentation
+ */
+Grain* VibrosonicsAPI::createDynamicGrain(uint8_t channel, WaveType waveType, FreqEnv freqEnv, AmpEnv ampEnv)
+{
+    Grain* newGrain = new Grain(channel, waveType);
+    newGrain->isDynamic = true;
+    grainList.pushGrain(newGrain);
+    newGrain->setFreqEnv(freqEnv);
+    newGrain->setAmpEnv(ampEnv);
+    newGrain->transitionTo(ATTACK);
+    return newGrain;
+}
+
+/**
  * Calls update for every grain in the grain list
  */
 void VibrosonicsAPI::updateGrains()
 {
-    Grain::update(&grainList);
+    grainList.updateAndReap();
 }
 
 /**

--- a/src/VibrosonicsAPI.h
+++ b/src/VibrosonicsAPI.h
@@ -114,10 +114,10 @@ public:
     void triggerGrains(Grain* grains, int numGrains, FreqEnv freqEnv, AmpEnv ampEnv);
 
     //! Creates a frequency envelope for a grain.
-    FreqEnv createFreqEnv(float targetFreq, float minFreq);
+    FreqEnv createFreqEnv(float attackFreq, float decayFreq, float sustainFreq, float releaseFreq);
 
     //! Creates an amplitude envelope for a grain.
-    AmpEnv createAmpEnv(float targetAmp, float minAmp, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve);
+    AmpEnv createAmpEnv(float attackAmp, int attackDuration, float decayAmp, int decayDuration, float sustainAmp, int sustainDuration, float releaseAmp, int releaseDuration, float curve);
 
     //! Sets the frequency envelope parameters for an array of grains.
     void setGrainFreqEnv(Grain* grains, int numGrains, FreqEnv freqEnv);

--- a/src/VibrosonicsAPI.h
+++ b/src/VibrosonicsAPI.h
@@ -107,20 +107,12 @@ public:
     Grain* createGrainArray(int numGrains, uint8_t channel, WaveType waveType);
 
     //! Updates an array of numPeaks grains sustain and release windows.
-    void triggerGrains(Grain* grains, int numPeaks, float** peakData);
+    void triggerGrains(Grain* grains, int numGrains, FreqEnv freqEnv, AmpEnv ampEnv);
 
-    //! Sets the attack state parameters for an array of grains
-    void shapeGrainAttack(Grain* grains, int numGrains, int duration,
-        float freqMod, float ampMod, float curve);
-
-    //! Sets the sustain state parameters for an array of grains
-    void shapeGrainSustain(Grain* grains, int numGrains, int duration,
-        float freqMod, float ampMod);
-
-    //! Sets the release state parameters for an array of grains
-    void shapeGrainRelease(Grain* grains, int numGrains, int duration,
-        float freqMod, float ampMod, float curve);
-
+    FreqEnv createFreqEnv(float targetFreq, float minFreq, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve);
+    FreqEnv createAmpEnv(float targetAmp, float minAmp, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve);
+    void setGrainFreqEnv(Grain* grains, int numGrains, FreqEnv freqEnv);
+    void setGrainAmpEnv(Grain* grains, int numGrains, AmpEnv ampEnv);
 private:
     // Fast Fourier Transform uses complex numbers
     float   vReal[WINDOW_SIZE];   //!< Real component of cosine amplitude of each frequency.

--- a/src/VibrosonicsAPI.h
+++ b/src/VibrosonicsAPI.h
@@ -102,16 +102,27 @@ public:
     //! Updates all grains in the globalGrainList
     void updateGrains();
 
-    //! Creates and returns an array of grains on desired chanel with specified
+    //! Creates and returns a static array of grains on desired chanel with specified
     //! wave type.
     Grain* createGrainArray(int numGrains, uint8_t channel, WaveType waveType);
+
+    //! Creates and returns a single dynamic grain with the specified channel and wave type.
+    //! Also takes frequency and amplitude envelopes for immediate triggering.
+    Grain* createDynamicGrain(uint8_t channel, WaveType waveType, FreqEnv freqEnv, AmpEnv ampEnv);
 
     //! Updates an array of numPeaks grains sustain and release windows.
     void triggerGrains(Grain* grains, int numGrains, FreqEnv freqEnv, AmpEnv ampEnv);
 
+    //! Creates a frequency envelope for a grain.
     FreqEnv createFreqEnv(float targetFreq, float minFreq, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve);
+
+    //! Creates an amplitude envelope for a grain.
     AmpEnv createAmpEnv(float targetAmp, float minAmp, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve);
+
+    //! Sets the frequency envelope parameters for an array of grains.
     void setGrainFreqEnv(Grain* grains, int numGrains, FreqEnv freqEnv);
+
+    //! Sets the amplitude envelope parameters for an array of grains.
     void setGrainAmpEnv(Grain* grains, int numGrains, AmpEnv ampEnv);
 private:
     // Fast Fourier Transform uses complex numbers

--- a/src/VibrosonicsAPI.h
+++ b/src/VibrosonicsAPI.h
@@ -114,7 +114,7 @@ public:
     void triggerGrains(Grain* grains, int numGrains, FreqEnv freqEnv, AmpEnv ampEnv);
 
     //! Creates a frequency envelope for a grain.
-    FreqEnv createFreqEnv(float targetFreq, float minFreq, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve);
+    FreqEnv createFreqEnv(float targetFreq, float minFreq);
 
     //! Creates an amplitude envelope for a grain.
     AmpEnv createAmpEnv(float targetAmp, float minAmp, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve);

--- a/src/VibrosonicsAPI.h
+++ b/src/VibrosonicsAPI.h
@@ -110,7 +110,7 @@ public:
     void triggerGrains(Grain* grains, int numGrains, FreqEnv freqEnv, AmpEnv ampEnv);
 
     FreqEnv createFreqEnv(float targetFreq, float minFreq, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve);
-    FreqEnv createAmpEnv(float targetAmp, float minAmp, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve);
+    AmpEnv createAmpEnv(float targetAmp, float minAmp, int attackDuration, int decayDuration, int sustainDuration, int releaseDuration, float curve);
     void setGrainFreqEnv(Grain* grains, int numGrains, FreqEnv freqEnv);
     void setGrainAmpEnv(Grain* grains, int numGrains, AmpEnv ampEnv);
 private:


### PR DESCRIPTION
### Issues Addressed
---

- Added frequency and amplitude envelopes for shaping rather than calling shape____ for each state
- Run no longer loops, ready waits to be told to transition to attack
- Decay state added and implemented
- triggerGrains now simply starts an array of grains based on passed in envelopes.

### Feature added
---
- Dynamic Grains:
    - Similar to AudioLab's dynamic waves, dynamic grains run for 1 lifetime (READY->RELEASE) and are then deleted. 
    - This makes it so that you are no longer limited by a predetermined number of grains! If for example percussion is detected multiple windows in a row, multiple grains will be created and played. This is much more flexible than static grains
    - Static grains function the same as before.
- Envelope Shaping
    - Grains are now shaped with envelopes, which is much closer to other implementations for different devices. 
### Misc
---
- Documentation has been updated across the API.
- Example inos have been updated to work with the grain overhaul.