### PR TITLE
Feat/update page layout

### DIFF
--- a/WebApp/src/atomics/checkbox.jsx
+++ b/WebApp/src/atomics/checkbox.jsx
@@ -1,0 +1,48 @@
+/***************************************************************
+ * File: checkbox.jsx
+ *
+ * Date: 11/17/2025
+ *
+ * Description: UI checkbox component for advanced mode
+ *
+ * Author: Bella Mann
+ ***************************************************************/
+
+import { useState } from "preact/hooks";
+
+/**
+ * @brief The Checkbox component is a skeleton for an audio analysis setting which uses checkbox
+ *        for reconfiguration
+ *
+ * @param {Object} setting - Expanded object for the checkbox settings
+ * @param {String} setting.label - Text to display next to checkbox
+ * @param {Number} [setting.initialValue] - Initial/Default value
+ * @param {function(string, boolean): void} setting.onChange - Callback that receives boolean state
+ */
+
+export default function Checkbox({ 
+    label, 
+    initialValue = 0, 
+    onChange 
+}) {
+    const [checked, setChecked] = useState(false);
+
+    const handleChange = (e) => {
+        const isChecked = e.target.checked;
+        setChecked(isChecked);
+        if(onChange)
+            onChange(label, isChecked);
+    };
+
+    return (
+        <label className="flex items-center gap-2 cursor-pointer">
+            <input
+                type="checkbox"
+                checked={checked}
+                onInput={handleChange}
+                className="w-4 h-4"
+            />
+            <span>{label}</span>
+        </label>
+    )
+}

--- a/WebApp/src/atomics/knob.jsx
+++ b/WebApp/src/atomics/knob.jsx
@@ -75,9 +75,9 @@ export default function Knob({
 
   return (
     // Parent container
-    <div className="flex items-center font-bold text-sm">
+    <div className="flex flex-col items-center font-bold text-sm">
       {/* Outside slider */}
-      <div className="w-[100px] h-[100px] flex items-center justify-center border-2 relative">
+      <div className="w-[100px] h-[100px] flex items-center justify-center relative">
         <div
           onMouseDown={handleMouseDown}
           className="w-[75px] h-[75px] bg-gray-800 border-2 border-gray-600 rounded-full relative cursor-ns-resize shadow-lg active:border-yellow-400 transition-colors"
@@ -92,15 +92,14 @@ export default function Knob({
             >
               <div className="w-1.5 h-3 bg-white mx-auto mt-2 rounded-full shadow-[0_0_5px_white]" />
             </div>
-
-            {/* Text value */}
-            <div className="absolute inset-0 flex items-center justify-center text-white pointer-events-none">
-              {title}
-            </div>
           </div>
         </div>
       </div>
-      Value: {Math.round(value)} {/* change this to be below*/}
+
+      {/* Text values */}
+      <div className="mt-2 justify-center">
+       {title}: {Math.round(value)}
+      </div>
     </div>
   );
 }

--- a/WebApp/src/atomics/knob.jsx
+++ b/WebApp/src/atomics/knob.jsx
@@ -80,7 +80,7 @@ export default function Knob({
       <div className="w-[100px] h-[100px] flex items-center justify-center relative">
         <div
           onMouseDown={handleMouseDown}
-          className="w-[75px] h-[75px] bg-gray-800 border-2 border-gray-600 rounded-full relative cursor-ns-resize shadow-lg active:border-yellow-400 transition-colors"
+          className="group w-[75px] h-[75px] bg-gray-800 border-2 border-gray-600 rounded-full relative cursor-ns-resize shadow-lg active:border-yellow-400 active:border-yellow-400 transition-colors"
         >
           {/* Knob */}
           <div className="w-[75px] h-[75px] bg-gray-800 border-2 rounded-full">
@@ -90,7 +90,7 @@ export default function Knob({
               // FIXME: convert to tailwindcss, `rotate-${rotation}` does not work as expected
               style={{ transform: `rotate(${rotation}deg)` }}
             >
-              <div className="w-1.5 h-3 bg-white mx-auto mt-2 rounded-full shadow-[0_0_5px_white]" />
+              <div className="w-1.5 h-3 bg-white mx-auto mt-2 rounded-full group-active:bg-yellow-400 shadow-[0_0_5px_white]" />
             </div>
           </div>
         </div>

--- a/WebApp/src/components/analysisModule.jsx
+++ b/WebApp/src/components/analysisModule.jsx
@@ -25,7 +25,8 @@ export default function AnalysisModule() {
   const [isAdvanced, setIsAdvanced] = useState(false);
   const [library, setLibrary] = useState([]);
   const [projectCount, setProjectCount] = useState(1);
-  const [currentProjectName, setCurrentProjectName] = useState("Project 1");
+  const [setupCount, setSetupCount] = useState(1);
+  const [currentProjectName, setCurrentProjectName] = useState("Project 1: Setup 1");
 
   const currentModData = EQ_PRESETS[activeGenre];
   const modeKey = isAdvanced ? "Advanced Percussion" : "Percussion";
@@ -77,8 +78,11 @@ export default function AnalysisModule() {
   const startNewProj = () => {
     if(window.confirm("Are you sure? Unsaved changes will be lost.")) {
         const nextCount = projectCount + 1;
+        const initialSetup = 1;
+
         setProjectCount(nextCount);
-        setCurrentProjectName(`Project ${nextCount}`);
+        setSetupCount(initialSetup);
+        setCurrentProjectName(`Project ${nextCount}: Setup ${initialSetup}`);
 
         setKnobValue({...INITIAL_PRESETS.knobs});
         setSliderValue(INITIAL_PRESETS.sliders);
@@ -87,9 +91,26 @@ export default function AnalysisModule() {
     }
   };
 
+  const saveProj = () => {
+    // 1. Save the CURRENT name (e.g., "Project 2: Setup 1") to the library
+    const newSave = {
+      id: Date.now(),
+      name: currentProjectName,
+      data: { knobValue, sliderValue, isAdvanced, activeGenre }
+    };
+    setLibrary((prev) => [...prev, newSave]);
+
+    // 2. Prepare the name for the NEXT save within this same project
+    const nextSetupNumber = setupCount + 1;
+    setSetupCount(nextSetupNumber);
+    setCurrentProjectName(`Project ${projectCount}: Setup ${nextSetupNumber}`);
+  };
+
   const clearCurrentSettings = () => {
     setKnobValue({...INITIAL_PRESETS.knobs});
     handleValueChange(0);
+    setIsAdvanced(!isAdvanced);
+    setActiveGenre('Rock');
   }
 
   const loadProject = (project) => {
@@ -107,7 +128,9 @@ export default function AnalysisModule() {
   const clearLibrary = () => {
     if(window.confirm("This will permanently delete ALL saved projects. Continue?")) {
       setLibrary([]);
-      setCurrentProjectName("Project 1");
+      setProjectCount(1);
+      setSetupCount(1);
+      setCurrentProjectName("Project 1: Setup 1");
     }
   };
 
@@ -213,7 +236,7 @@ export default function AnalysisModule() {
         
         <div className="flex gap-4 mb-6">
           <button 
-            onClick={() => saveProject()} 
+            onClick={saveProj}
             className="bg-green-600 text-white px-6 py-2 rounded-lg font-bold hover:bg-green-700 transition"
           >
             Save Current Setup

--- a/WebApp/src/components/analysisModule.jsx
+++ b/WebApp/src/components/analysisModule.jsx
@@ -12,15 +12,22 @@ import Slider from "../atomics/slider";
 import Knob from "../atomics/knob";
 import EQ_PRESETS from "../data/eqSettings.json";
 import { useState } from "react";
+import Checkbox from "../atomics/checkbox";
+import PERCUSSION_PRESETS from "../data/precussionSettings.json";
 
 // TODO: pass in a interface prop to define different knobs, sliders, etc.
 export default function AnalysisModule() {
   const [activeGenre, setActiveGenre] = useState("Rock");
   const [knobValue, setKnobValue] = useState({});
   const [sliderValue, setSliderValue] = useState({});
+  const [isAdvanced, setIsAdvanced] = useState(false);
 
   const currentSliders = EQ_PRESETS[activeGenre];
   const currentKnobs = EQ_PRESETS[activeGenre];
+
+  const modeKey = isAdvanced ? "Advanced Percussion" : "Percussion";
+  const percussionData = PERCUSSION_PRESETS[modeKey];
+  const percussionKnobs = PERCUSSION_PRESETS[modeKey];
 
   const handleKnobChange = (id, value) => {
     setKnobValue((prev) => ({ ...prev, [id]: value }));
@@ -34,6 +41,10 @@ export default function AnalysisModule() {
     console.log(
       String("Slider") + String(id) + String("Value: ") + String(value)
     );
+  };
+
+  const handleCheckboxChange = (id, value) => {
+    setIsAdvanced(value);
   };
 
   return (
@@ -58,36 +69,73 @@ export default function AnalysisModule() {
       </div>
 
       <div className="flex flex-wrap gap-8 p-8 bg-gray-200 rounded-xl shadow-inner max-w-3xl">
-        {currentKnobs.map((knobData) => (
-          <div key={knobData.id} className="flex flex-col items-center gap-2">
-            <Knob
-              key={knobData.id}
-              title={knobData.title}
-              value={knobValue[knobData.id] ?? knobData.default ?? 0}
-              min={knobData.min}
-              max={knobData.max}
-              step={0.1}
-              onChange={(value) => handleKnobChange(knobData.id, value)}
+          {currentKnobs.map((knobData) => (
+            <div key={knobData.id} className="flex flex-col items-center gap-2">
+              <Knob
+                key={knobData.id}
+                title={knobData.title}
+                value={knobValue[knobData.id] ?? knobData.default ?? 0}
+                min={knobData.min}
+                max={knobData.max}
+                step={0.1}
+                onChange={(value) => handleKnobChange(knobData.id, value)}
+              />
+              <span className="font-bold text-gray-700">{knobData.label}</span>
+            </div>
+          ))}
+
+        <div className="flex flex-row gap-5 p-5">
+          {currentSliders.map((slider) => (
+            <Slider
+              key={slider.id}
+              title={slider.title}
+              initialValue={sliderValue[slider.id] ?? slider.default ?? 0}
+              min={slider.min}
+              max={slider.max}
+              step={2}
+              onInput={(sliderValue) =>
+                handleSliderChange(slider.id, sliderValue)
+              }
             />
-            <span className="font-bold text-gray-700">{knobData.label}</span>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
 
-      <div className="flex flex-row gap-5 p-5">
-        {currentSliders.map((slider) => (
-          <Slider
-            key={slider.id}
-            title={slider.title}
-            initialValue={sliderValue[slider.id] ?? slider.default ?? 0}
-            min={slider.min}
-            max={slider.max}
-            step={2}
-            onInput={(sliderValue) =>
-              handleSliderChange(slider.id, sliderValue)
-            }
+      <div className="p-4">
+        <h2 className="text-xl font-bold mb-4">Percussion Settings
+          <Checkbox
+            label="Advanced Mode"
+            onChange={(id, val) => handleCheckboxChange(id, val)}
           />
-        ))}
+        </h2>
+
+        <div className={`${isAdvanced ? 'Advanced Percussion' : 'Percussion'} flex flex-row gap-5 p-5`}>
+          <div className="flex flex-wrap gap-8 p-8 bg-gray-200 rounded-xl shadow-inner max-w-3xl">
+              {percussionData.map((data) => (
+                <div key={data.id} className="flex flex-col items-center gap-8">
+                  <Knob
+                    key={data.id}
+                    title={data.title}
+                    value={knobValue[data.id] ?? data.initialValue ?? 0}
+                    min={data.min}
+                    max={data.max}
+                    step={0.1}
+                    onChange={(value) => handleKnobChange(data.id, value)}
+                  />
+
+                  <Slider
+                    key={data.id}
+                    title={data.title}
+                    initialValue={sliderValue[data.id] ?? data.initialValue ?? 0}
+                    min={data.min}
+                    max={data.max}
+                    step={2}
+                    onInput={(val) => handleSliderChange(data.id, val)}
+                  />
+                </div>
+              ))}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/WebApp/src/components/analysisModule.jsx
+++ b/WebApp/src/components/analysisModule.jsx
@@ -14,6 +14,8 @@ import EQ_PRESETS from "../data/eqSettings.json";
 import { useState } from "react";
 import Checkbox from "../atomics/checkbox";
 import PERCUSSION_PRESETS from "../data/precussionSettings.json";
+import INITIAL_PRESETS from "../data/initalStates.json";
+import { createProject } from "../utils/configurations.js";
 
 // TODO: pass in a interface prop to define different knobs, sliders, etc.
 export default function AnalysisModule() {
@@ -21,13 +23,14 @@ export default function AnalysisModule() {
   const [knobValue, setKnobValue] = useState({});
   const [sliderValue, setSliderValue] = useState({});
   const [isAdvanced, setIsAdvanced] = useState(false);
+  const [library, setLibrary] = useState([]);
+  const [currentProjectName, setCurrentProjectName] = useState("New Project");
 
-  const currentSliders = EQ_PRESETS[activeGenre];
-  const currentKnobs = EQ_PRESETS[activeGenre];
+  const currentModData = EQ_PRESETS[activeGenre];
+  const inits = INITIAL_PRESETS;
 
   const modeKey = isAdvanced ? "Advanced Percussion" : "Percussion";
   const percussionData = PERCUSSION_PRESETS[modeKey];
-  const percussionKnobs = PERCUSSION_PRESETS[modeKey];
 
   const handleKnobChange = (id, value) => {
     setKnobValue((prev) => ({ ...prev, [id]: value }));
@@ -47,76 +50,96 @@ export default function AnalysisModule() {
     setIsAdvanced(value);
   };
 
+  const saveProject = (name) => {
+    const newSave = createProject(name, library.length, {
+      id: Date.now(),
+      name: name || `Project ${library.length + 1}`,
+        knobValue: {...knobValue},
+        sliderValue: {...sliderValue},
+        isAdvanced,
+        activeGenre
+      });
+    setLibrary((prev) => [...prev, newSave]);
+  };
+
+  const startNewProj = () => {
+    if(window.confirm("Are you sure? Unsaved changes will be lost.")) {
+        setKnobValue({...INITIAL_PRESETS.knobs});
+        setSliderValue(INITIAL_PRESETS.sliders);
+        setIsAdvanced(INITIAL_PRESETS.isAdvanced);
+        setActiveGenre(INITIAL_PRESETS.activeGenre);
+    }
+  };
+
+  const applyProject = (projectData) => {
+    setKnobValue(projectData.knobs);
+    setSliderValue(projectData.sliders);
+    setIsAdvanced(projectData.isAdvanced);
+    setActiveGenre(projectData.activeGenre || 'Rock');
+  }
+
+  const loadProject = (project) => {
+    if(!project || !project.data) return;
+
+    const { knobValue, sliderValue, isAdvanced, activeGenre } = project.data;
+
+    setKnobValue(knobValue);
+    setSliderValue(sliderValue);
+    setIsAdvanced(isAdvanced);
+    setActiveGenre(activeGenre || 'Rock');
+    setCurrentProjectName(project.data.name);
+  }
+
+  const clearLibrary = () => {
+    if(window.confirm("This will permanently delete ALL saved projects. Continue?")) {
+      setLibrary([]);
+    }
+  };
+
   return (
     <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">EQ</h1>
-
-      <div className="flex gap-2.5 mb-8">
-        {Object.keys(EQ_PRESETS).map((genre) => (
-          <button
-            className={`p-3 border border-[#ccc] rounded-lg cursor-pointer transition-colors
-            ${
-              activeGenre === genre
-                ? "bg-[#fcd34d] font-bold"
-                : "bg-[#e5e7eb] font-normal"
-            }`}
-            key={genre}
-            onClick={() => setActiveGenre(genre)}
-          >
-            {` ${genre} `}
-          </button>
-        ))}
-      </div>
-
-      <div className="flex flex-wrap gap-8 p-8 bg-gray-200 rounded-xl shadow-inner max-w-3xl">
-          {currentKnobs.map((knobData) => (
-            <div key={knobData.id} className="flex flex-col items-center gap-2">
-              <Knob
-                key={knobData.id}
-                title={knobData.title}
-                value={knobValue[knobData.id] ?? knobData.default ?? 0}
-                min={knobData.min}
-                max={knobData.max}
-                step={0.1}
-                onChange={(value) => handleKnobChange(knobData.id, value)}
-              />
-              <span className="font-bold text-gray-700">{knobData.label}</span>
-            </div>
-          ))}
-
-        <div className="flex flex-row gap-5 p-5">
-          {currentSliders.map((slider) => (
-            <Slider
-              key={slider.id}
-              title={slider.title}
-              initialValue={sliderValue[slider.id] ?? slider.default ?? 0}
-              min={slider.min}
-              max={slider.max}
-              step={2}
-              onInput={(sliderValue) =>
-                handleSliderChange(slider.id, sliderValue)
-              }
-            />
+      <h1 className="text-xl font-bold mb-4">{currentProjectName}</h1>
+      
+      <div className="flex flex-row flex-wrap items-start gap-8 p-8 mt-8 rounded-xl shadow-md border border-gray-100">
+        {/*EQ Presets*/}
+        <h2 className="text-xl font-bold mb-4">EQ</h2>
+        <div className="flex gap-2.5 mb-8">
+          {Object.keys(EQ_PRESETS).map((genre) => (
+            <button
+              className={`p-3 border border-[#ccc] rounded-lg cursor-pointer transition-colors
+              ${
+                activeGenre === genre
+                  ? "bg-[#fcd34d] font-bold"
+                  : "bg-[#e5e7eb] font-normal"
+              }`}
+              key={genre}
+              onClick={() => setActiveGenre(genre)}
+            >
+              {` ${genre} `}
+            </button>
           ))}
         </div>
-      </div>
+      
 
-      <div className="p-4">
+        {/*Precussion Presets*/}
         <h2 className="text-xl font-bold mb-4">Percussion Settings
           <Checkbox
             label="Advanced Mode"
             onChange={(id, val) => handleCheckboxChange(id, val)}
           />
         </h2>
+      </div>
 
-        <div className={`${isAdvanced ? 'Advanced Percussion' : 'Percussion'} flex flex-row gap-5 p-5`}>
+      <div className="flex flex-row flex-wrap items-start gap-8 mt-8 rounded-xl shadow-md border border-gray-100">
+        {/*EQ Knobs and Sliders*/}
+        <div className="flex flex-row gap-5 p-5">
           <div className="flex flex-wrap gap-8 p-8 bg-gray-200 rounded-xl shadow-inner max-w-3xl">
-              {percussionData.map((data) => (
-                <div key={data.id} className="flex flex-col items-center gap-8">
+              {currentModData.map((data) => (
+                <div key={data.id} className="flex flex-col items-center gap-2">
                   <Knob
                     key={data.id}
                     title={data.title}
-                    value={knobValue[data.id] ?? data.initialValue ?? 0}
+                    value={knobValue[data.id] ?? data.default ?? 0}
                     min={data.min}
                     max={data.max}
                     step={0.1}
@@ -126,15 +149,80 @@ export default function AnalysisModule() {
                   <Slider
                     key={data.id}
                     title={data.title}
-                    initialValue={sliderValue[data.id] ?? data.initialValue ?? 0}
+                    initialValue={sliderValue[data.id] ?? data.default ?? 0}
                     min={data.min}
                     max={data.max}
                     step={2}
-                    onInput={(val) => handleSliderChange(data.id, val)}
+                    onInput={(sliderValue) => handleSliderChange(data.id, sliderValue)}
                   />
+                  <span className="font-bold text-gray-700">{data.label}</span>
                 </div>
               ))}
           </div>
+        </div>
+
+        {/*Percussion Knobs and Sliders*/}
+        <div className="p-4">
+          <div className={`${isAdvanced ? 'Advanced Percussion' : 'Percussion'} flex flex-row gap-5 p-5`}>
+            <div className="flex flex-wrap gap-8 p-8 bg-gray-200 rounded-xl shadow-inner max-w-3xl">
+                {percussionData.map((data) => (
+                  <div key={data.id} className="flex flex-col items-center gap-8">
+                    <Knob
+                      key={data.id}
+                      title={data.title}
+                      value={knobValue[data.id] ?? data.initialValue ?? 0}
+                      min={data.min}
+                      max={data.max}
+                      step={0.1}
+                      onChange={(value) => handleKnobChange(data.id, value)}
+                    />
+
+                    <Slider
+                      key={data.id}
+                      title={data.title}
+                      initialValue={sliderValue[data.id] ?? data.initialValue ?? 0}
+                      min={data.min}
+                      max={data.max}
+                      step={2}
+                      onInput={(val) => handleSliderChange(data.id, val)}
+                    />
+                  </div>
+                ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-8 mt-8 bg-white rounded-xl shadow-md border border-gray-100">
+        <h2 className="text-2xl font-bold mb-6">Project Library</h2>
+        
+        <div className="flex gap-4 mb-6">
+          <button 
+            onClick={() => saveProject()} 
+            className="bg-green-600 text-white px-6 py-2 rounded-lg font-bold hover:bg-green-700 transition"
+          >
+            Save Current Setup
+          </button>
+          <button 
+            onClick={startNewProj} 
+            className="bg-blue-600 text-white px-6 py-2 rounded-lg font-bold hover:bg-blue-700 transition"
+          >
+            + Start New Project
+          </button>
+          <button onClick={clearLibrary} className="bg-red-600 text-white px-6 py-2 rounded-lg font-bold">
+            Clear All Projects
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {library.map((project) => (
+            <div key={project.id} className="p-4 border rounded-lg flex justify-between items-center bg-gray-50">
+              <span className="font-medium">{project.name}</span>
+              <button onClick={() => {loadProject(project)}} className="text-sm text-blue-600 hover:underline">
+                Load Settings
+              </button>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/WebApp/src/components/analysisModule.jsx
+++ b/WebApp/src/components/analysisModule.jsx
@@ -8,7 +8,7 @@
  * Author: Ivan Wong and Bella Mann
  ***************************************************************/
 
-import Slider from "../atomics/slider";
+//import Slider from "../atomics/slider";
 import Knob from "../atomics/knob";
 import EQ_PRESETS from "../data/eqSettings.json";
 import { useState } from "react";
@@ -24,11 +24,10 @@ export default function AnalysisModule() {
   const [sliderValue, setSliderValue] = useState({});
   const [isAdvanced, setIsAdvanced] = useState(false);
   const [library, setLibrary] = useState([]);
-  const [currentProjectName, setCurrentProjectName] = useState("New Project");
+  const [projectCount, setProjectCount] = useState(1);
+  const [currentProjectName, setCurrentProjectName] = useState("Project 1");
 
   const currentModData = EQ_PRESETS[activeGenre];
-  const inits = INITIAL_PRESETS;
-
   const modeKey = isAdvanced ? "Advanced Percussion" : "Percussion";
   const percussionData = PERCUSSION_PRESETS[modeKey];
 
@@ -46,7 +45,20 @@ export default function AnalysisModule() {
     );
   };
 
-  const handleCheckboxChange = (id, value) => {
+  const handleValueChange = (id, value) => {
+    const numValue = Number(value);
+
+    const allPresets = [...percussionData, ...currentModData] // ADD MORE PRESETS HERE
+    const preset = allPresets.find(p => p.id === id);
+    const maxValue = preset ? preset.max : 100;
+    const minValue = preset ? preset.min : 0;
+
+    const clampedVal = Math.max(minValue, Math.min(maxValue, numValue));
+
+    setKnobValue((prev) => ({ ...prev, [id]: clampedVal }));
+  }
+
+  const handleCheckboxChange = (value) => {
     setIsAdvanced(value);
   };
 
@@ -64,6 +76,10 @@ export default function AnalysisModule() {
 
   const startNewProj = () => {
     if(window.confirm("Are you sure? Unsaved changes will be lost.")) {
+        const nextCount = projectCount + 1;
+        setProjectCount(nextCount);
+        setCurrentProjectName(`Project ${nextCount}`);
+
         setKnobValue({...INITIAL_PRESETS.knobs});
         setSliderValue(INITIAL_PRESETS.sliders);
         setIsAdvanced(INITIAL_PRESETS.isAdvanced);
@@ -71,11 +87,9 @@ export default function AnalysisModule() {
     }
   };
 
-  const applyProject = (projectData) => {
-    setKnobValue(projectData.knobs);
-    setSliderValue(projectData.sliders);
-    setIsAdvanced(projectData.isAdvanced);
-    setActiveGenre(projectData.activeGenre || 'Rock');
+  const clearCurrentSettings = () => {
+    setKnobValue({...INITIAL_PRESETS.knobs});
+    handleValueChange(0);
   }
 
   const loadProject = (project) => {
@@ -87,12 +101,13 @@ export default function AnalysisModule() {
     setSliderValue(sliderValue);
     setIsAdvanced(isAdvanced);
     setActiveGenre(activeGenre || 'Rock');
-    setCurrentProjectName(project.data.name);
+    setCurrentProjectName(project.name);
   }
 
   const clearLibrary = () => {
     if(window.confirm("This will permanently delete ALL saved projects. Continue?")) {
       setLibrary([]);
+      setCurrentProjectName("Project 1");
     }
   };
 
@@ -120,18 +135,17 @@ export default function AnalysisModule() {
           ))}
         </div>
       
-
         {/*Precussion Presets*/}
         <h2 className="text-xl font-bold mb-4">Percussion Settings
           <Checkbox
             label="Advanced Mode"
-            onChange={(id, val) => handleCheckboxChange(id, val)}
+            onChange={(id, val) => handleCheckboxChange(val)}
           />
         </h2>
       </div>
 
-      <div className="flex flex-row flex-wrap items-start gap-8 mt-8 rounded-xl shadow-md border border-gray-100">
-        {/*EQ Knobs and Sliders*/}
+      <div className="flex flex-row items-center items-stretch gap-8 mt-8 rounded-xl shadow-md border border-gray-100">
+        {/*EQ Knobs and User Input*/}
         <div className="flex flex-row gap-5 p-5">
           <div className="flex flex-wrap gap-8 p-8 bg-gray-200 rounded-xl shadow-inner max-w-3xl">
               {currentModData.map((data) => (
@@ -146,27 +160,27 @@ export default function AnalysisModule() {
                     onChange={(value) => handleKnobChange(data.id, value)}
                   />
 
-                  <Slider
-                    key={data.id}
-                    title={data.title}
-                    initialValue={sliderValue[data.id] ?? data.default ?? 0}
-                    min={data.min}
-                    max={data.max}
-                    step={2}
-                    onInput={(sliderValue) => handleSliderChange(data.id, sliderValue)}
-                  />
+                  <div className="flex flex-col items-center gap-1">
+                    <input
+                        type="number"
+                        className="w-16 p-1 text-center bg-white border border-gray-400 rounded text-sm"
+                        value={Math.round(knobValue[data.id] ?? data.initialValue ?? 0)}
+                        onChange={(e) => handleValueChange(data.id, (e.target instanceof HTMLInputElement ? e.target.value : ""))}
+                        min={data.min}
+                        max={data.max}
+                      />
+                    </div>
                   <span className="font-bold text-gray-700">{data.label}</span>
                 </div>
               ))}
           </div>
         </div>
 
-        {/*Percussion Knobs and Sliders*/}
-        <div className="p-4">
+        {/*Percussion Knobs and User Input*/}
           <div className={`${isAdvanced ? 'Advanced Percussion' : 'Percussion'} flex flex-row gap-5 p-5`}>
             <div className="flex flex-wrap gap-8 p-8 bg-gray-200 rounded-xl shadow-inner max-w-3xl">
                 {percussionData.map((data) => (
-                  <div key={data.id} className="flex flex-col items-center gap-8">
+                  <div key={data.id} className="flex flex-col items-center gap-2">
                     <Knob
                       key={data.id}
                       title={data.title}
@@ -177,22 +191,23 @@ export default function AnalysisModule() {
                       onChange={(value) => handleKnobChange(data.id, value)}
                     />
 
-                    <Slider
-                      key={data.id}
-                      title={data.title}
-                      initialValue={sliderValue[data.id] ?? data.initialValue ?? 0}
-                      min={data.min}
-                      max={data.max}
-                      step={2}
-                      onInput={(val) => handleSliderChange(data.id, val)}
-                    />
+                    <div className="flex flex-col items-center gap-1">
+                      <input
+                        type="number"
+                        className="w-16 p-1 text-center bg-white border border-gray-400 rounded text-sm"
+                        value={Math.round(knobValue[data.id] ?? data.initialValue ?? 0)}
+                        onChange={(e) => handleValueChange(data.id, (e.target instanceof HTMLInputElement ? e.target.value : ""))}
+                        min={data.min}
+                        max={data.max}
+                      />
+                    </div>
                   </div>
                 ))}
             </div>
           </div>
         </div>
-      </div>
 
+      {/*Project Library Buttons*/}
       <div className="p-8 mt-8 bg-white rounded-xl shadow-md border border-gray-100">
         <h2 className="text-2xl font-bold mb-6">Project Library</h2>
         
@@ -212,9 +227,17 @@ export default function AnalysisModule() {
           <button onClick={clearLibrary} className="bg-red-600 text-white px-6 py-2 rounded-lg font-bold">
             Clear All Projects
           </button>
+
+          <button 
+            onClick={clearCurrentSettings} 
+            className="bg-orange-600 text-white px-6 py-2 rounded-lg font-bold hover:bg-orange-700 transition"
+          >
+            Clear Current Settings
+          </button>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/*Load Settings Button*/}
+        <div className="flex flex-col md:grid-cols-2 gap-4">
           {library.map((project) => (
             <div key={project.id} className="p-4 border rounded-lg flex justify-between items-center bg-gray-50">
               <span className="font-medium">{project.name}</span>

--- a/WebApp/src/components/footer.jsx
+++ b/WebApp/src/components/footer.jsx
@@ -16,7 +16,7 @@
 const Footer = () => {
   return (
     <div className="font-bold mt-10 border-t-2 border-black p-4 flex w-full h-[60px]">
-      <p>footer</p>      
+      <p>Developed by the 2024-26 Vibrosonics Software Teams under the leadership of Dr. Chet Udell, in collaboration with Cymaspace and contributors Ivan Wong, Danielle Chang, Bella Mann, Allyson Aoki, and alumni.</p>      
     </div>
   );
 };

--- a/WebApp/src/data/eqSettings.json
+++ b/WebApp/src/data/eqSettings.json
@@ -1,23 +1,23 @@
 {
   "Rock": [
-    { "id": "bass", "title": "Bass", "min": 0, "max": 100 },
-    { "id": "mid", "title": "Mid", "min": 0, "max": 10 },
-    { "id": "treb", "title": "Treble", "min": 0, "max": 10 },
-    { "id": "pres", "title": "Presence", "min": 0, "max": 10 }
+    { "id": "rockBass", "title": "Bass", "min": 0, "max": 100 },
+    { "id": "rockMid", "title": "Mid", "min": 0, "max": 10 },
+    { "id": "rockTreb", "title": "Treble", "min": 0, "max": 10 },
+    { "id": "rockPres", "title": "Presence", "min": 0, "max": 10 }
   ],
   "EDM": [
-    { "id": "bass", "title": "Bass", "min": 0, "max": 100 },
-    { "id": "treble", "title": "Highs", "min": 0, "max": 10 },
-    { "id": "sub", "title": "Sub-Bass", "min": 0, "max": 10 }
+    { "id": "edmBass", "title": "Bass", "min": 0, "max": 100 },
+    { "id": "edmTreble", "title": "Highs", "min": 0, "max": 10 },
+    { "id": "edmSub", "title": "Sub-Bass", "min": 0, "max": 10 }
   ],
   "Country": [
-    { "id": "bass", "title": "Bass", "min": 0, "max": 100 },
-    { "id": "mid", "title": "Mid", "min": 0, "max": 100 },
-    { "id": "twang", "title": "Twang", "min": 0, "max": 10 }
+    { "id": "countryBass", "title": "Bass", "min": 0, "max": 100 },
+    { "id": "countryMid", "title": "Mid", "min": 0, "max": 100 },
+    { "id": "countryTwang", "title": "Twang", "min": 0, "max": 10 }
   ],
   "Jazz": [
-    { "id": "low", "title": "Low", "min": 0, "max": 100 },
-    { "id": "mid", "title": "Mid", "min": 0, "max": 100 },
-    { "id": "high", "title": "High", "min": 0, "max": 10 }
+    { "id": "jazzLow", "title": "Low", "min": 0, "max": 100 },
+    { "id": "jazzMid", "title": "Mid", "min": 0, "max": 100 },
+    { "id": "jazzHigh", "title": "High", "min": 0, "max": 10 }
   ]
 }

--- a/WebApp/src/data/initalStates.json
+++ b/WebApp/src/data/initalStates.json
@@ -1,0 +1,21 @@
+{
+  "knobs": {
+    "bass": 0,
+    "mid": 0,
+    "treble": 0,
+    "presence": 0
+  },
+  "sliders": {
+    "bass": 0,
+    "mid": 0,
+    "treble": 0,
+    "presence": 0
+  },
+  "percussion": {
+    "cymbal": 0,
+    "snare": 0,
+    "bass": 0
+  },
+  "isAdvanced": false,
+  "activeGenre": "Rock"
+}

--- a/WebApp/src/data/noisecancellationSettings.json
+++ b/WebApp/src/data/noisecancellationSettings.json
@@ -1,0 +1,7 @@
+{
+  "Noise Cancellation": [
+    { "id": "referenceCells", "title": "Reference Cells", "min": 0, "max": 100 },
+    { "id": "guardCells", "title": "Guard Cells", "min": 0, "max": 100 },
+    { "id": "bias", "title": "Biass", "min": 0, "max": 100 }
+  ]
+}

--- a/WebApp/src/data/precussionSettings.json
+++ b/WebApp/src/data/precussionSettings.json
@@ -1,0 +1,12 @@
+{
+  "Percussion": [
+    { "id": "cymbal", "title": "Cymbal", "min": 0, "max": 100, "initialValue": 0 },
+    { "id": "snare", "title": "Snare", "min": 0, "max": 100, "initialValue": 0 },
+    { "id": "bass", "title": "Bass", "min": 0, "max": 10, "initialValue": 0 }
+  ],
+  "Advanced Percussion": [
+    { "id": "fluxThreshold", "title": "Flux Threshold", "min": 0, "max": 100, "initialValue": 0 },
+    { "id": "energyThreshold", "title": "Energy Threshold", "min": 0, "max": 100, "initialValue": 0 },
+    { "id": "entropyThreshold", "title": "Entropy Threshold", "min": 0, "max": 100, "initialValue": 0 }
+  ]
+}

--- a/WebApp/src/data/precussionSettings.json
+++ b/WebApp/src/data/precussionSettings.json
@@ -1,8 +1,8 @@
 {
   "Percussion": [
-    { "id": "cymbal", "title": "Cymbal", "min": 0, "max": 100, "initialValue": 0 },
-    { "id": "snare", "title": "Snare", "min": 0, "max": 100, "initialValue": 0 },
-    { "id": "bass", "title": "Bass", "min": 0, "max": 10, "initialValue": 0 }
+    { "id": "precussionCymbal", "title": "Cymbal", "min": 0, "max": 100, "initialValue": 0 },
+    { "id": "precussionSnare", "title": "Snare", "min": 0, "max": 100, "initialValue": 0 },
+    { "id": "precussionBass", "title": "Bass", "min": 0, "max": 10, "initialValue": 0 }
   ],
   "Advanced Percussion": [
     { "id": "fluxThreshold", "title": "Flux Threshold", "min": 0, "max": 100, "initialValue": 0 },

--- a/WebApp/src/pages/landingPage.jsx
+++ b/WebApp/src/pages/landingPage.jsx
@@ -59,13 +59,13 @@ const LandingPage = () => {
           </div>
           <div className="flex flex-col">
             <button
-              className="border-2 border-amber-500 cursor-pointer mb-5"
+              className="p-3 bg-[#fcd34d] border border-[#ccc] rounded-lg cursor-pointer font-bold shadow-sm hover:bg-[#fbbf24]"
               onClick={ () => route("/network", false) }
             >
               Connect to Network
             </button>
             <button
-              className={`border-2 border-amber-500 cursor-pointer ${isAudioSettingBtnVisible ? "visible" : "invisible"}`}
+              className={`p-3 bg-[#fcd34d] border border-[#ccc] rounded-lg cursor-pointer font-bold shadow-sm hover:bg-[#fbbf24] ${isAudioSettingBtnVisible ? "visible" : "invisible"}`}
               onClick={ () => route("/modules", false) }
             >
               Adjust Audio Settings

--- a/WebApp/src/pages/modulesPage.jsx
+++ b/WebApp/src/pages/modulesPage.jsx
@@ -15,7 +15,6 @@ const ModulesPage = () => {
   return (
     <div>
       <h1 className="font-bold mt-10">
-        Modules page
         <AnalysisModule />
       </h1>
     </div>

--- a/WebApp/src/pages/networkPage.jsx
+++ b/WebApp/src/pages/networkPage.jsx
@@ -76,7 +76,7 @@ const NetworkPage = () => {
 
         {/* Scan network button */}
         <button
-          className="border-3 border-amber-500 p-1 cursor-pointer mt-3 text-xl font-semibold rounded-sm"
+          className="p-3 bg-[#fcd34d] border border-[#ccc] rounded-lg cursor-pointer font-bold shadow-sm hover:bg-[#fbbf24]"
           onClick={getNetworks}
         >
           Scan Networks

--- a/WebApp/src/utils/configurations.js
+++ b/WebApp/src/utils/configurations.js
@@ -1,0 +1,15 @@
+import { useState } from "preact/hooks";
+
+export const createProject = (name, libraryLength, currentValues) => {
+  return {
+    id: Date.now(),
+    name: name || `Project ${libraryLength + 1}`,
+    data: {
+      knobValue: { ...currentValues.knobValue },
+      sliderValue: { ...currentValues.sliderValue },
+      isAdvanced: currentValues.isAdvanced,
+      activeGenre: currentValues.activeGenre
+    }
+  };
+};
+


### PR DESCRIPTION
Changes made:
- Got rid of "modules page" at top of modules page
- Added "Project i" for each project to replace modules page title (increments for every new project)
- - Added checkbox functionality within checkbox.jsx
- Added Percussion Settings and Advanced Mode 
- Changed eqSettings.json for more specific variable names
- Added percussionSettings.json 
- Added initialStates.json for easier initialization
- Added noisecancellationSettings.json for future use (next pr hopefully)
- Swapped slider functionality out for user text input functionality (kept slider functionality for possible later use)
- Added color to the knobs when clicked
- Added project library section
- "Save Current Setup" button that saves the current presets, increments setup number, and puts them into an incremented project
- Within "Save Current Setup", added "Load Settings" which automatically loads the presaved settings onto the knobs and inputs
- "+ Start New Project" button increments the project number and resets the setup number to 1, restarting the setup number count in a new project
- "Clear All Projects" button clears all the projects in the library
- "Clear Current Settings" button clears the current settings on the board without getting rid of Project Library data
- Expanded footer description

Next Steps:
- Clean up analysisModule.jsx return
- Initialize Noise Cancellation functionality
- Create a mute channel option