### PR TITLE
feat: Add configurable sketch for major peaks module

### DIFF
--- a/src/Configurable/Configurable.ino
+++ b/src/Configurable/Configurable.ino
@@ -59,7 +59,7 @@ Spectrogram melodicSpectrogram = Spectrogram(2, WINDOW_SIZE_OVERLAP);
 ModuleGroup melodic = ModuleGroup(&melodicSpectrogram);
 
 // NOTE: using float** for the type here is going to cause issues when adding percussion - find more elegant solution
-ModuleInterface<float**>* modules[NUM_OUT_CH] = { nullptr };
+ModuleInterface<float**>* analysisModules[NUM_OUT_CH] = { nullptr };
 
 void setup() {
   Serial.begin(115200);
@@ -131,10 +131,10 @@ void loop() {
   melodic.runAnalysis();
 
   for (int i = 0; i < NUM_OUT_CH; i++){
-    if (loadedConfig.outputs[i]->moduleType == MAJORPEAKS){
-      float **analysisData = modules[i]->getOutput();
-      synthesizePeak(i, analysisData[MP_FREQ][0], analysisData[MP_AMP][0], loadedConfig.outputs[i]->freqLow, loadedConfig.outputs[i]->freqHigh, loadedConfig.outputs[i]->frequencyMapping);
-      AudioLab.mapAmplitudes(i, loadedConfig.outputs[i]->minAmpNorm);
+    if (loadedConfig.modules[i]->moduleType == MAJORPEAKS){
+      float **analysisData = analysisModules[i]->getOutput();
+      synthesizePeak(i, analysisData[MP_FREQ][0], analysisData[MP_AMP][0], loadedConfig.modules[i]->freqLow, loadedConfig.modules[i]->freqHigh, loadedConfig.modules[i]->frequencyMapping);
+      AudioLab.mapAmplitudes(i, loadedConfig.modules[i]->minAmpNorm);
     }
   }
 
@@ -146,20 +146,20 @@ void clearOutputModules(){
   melodic.clearModules();
   // delete old modules
   for (int i = 0; i < NUM_OUT_CH; i++) {
-    if (modules[i] != nullptr){
-      delete modules[i];
-      modules[i] = nullptr;
+    if (analysisModules[i] != nullptr){
+      delete analysisModules[i];
+      analysisModules[i] = nullptr;
     }
   }
 }
 
 void assignOutputModules(){
   for (int i = 0; i < NUM_OUT_CH; i++){
-    if (loadedConfig.outputs[i]->moduleType == MAJORPEAKS){
-      MajorPeaksConfig* majorPeaks = static_cast<MajorPeaksConfig*>(loadedConfig.outputs[i]);
-      modules[i] = new MajorPeaks(majorPeaks->maxPeaks);
-      modules[i]->setWindowSize(WINDOW_SIZE_OVERLAP);
-      melodic.addModule(modules[i], loadedConfig.outputs[i]->freqLow, loadedConfig.outputs[i]->freqHigh);
+    if (loadedConfig.modules[i]->moduleType == MAJORPEAKS){
+      MajorPeaksConfig* majorPeaks = static_cast<MajorPeaksConfig*>(loadedConfig.modules[i]);
+      analysisModules[i] = new MajorPeaks(majorPeaks->maxPeaks);
+      analysisModules[i]->setWindowSize(WINDOW_SIZE_OVERLAP);
+      melodic.addModule(analysisModules[i], loadedConfig.modules[i]->freqLow, loadedConfig.modules[i]->freqHigh);
     }
   }
 }

--- a/src/Configurable/Configurable.ino
+++ b/src/Configurable/Configurable.ino
@@ -1,13 +1,14 @@
 #include "VibrosonicsAPI.h"
 #include "storage.h"
 
-MajorPeaksConfig exampleMajorPeaksConfigs[4] = {
+// array of possible configurations for single outputs
+MajorPeaksConfig exampleMajorPeaksConfigs[3] = {
   { 400, 1000, OCTAVE, 10000, 1 },
   { 1000, 3600, OCTAVE, 10000, 1 },
   { 0, 4000, NONE, 10000, 32 },
-  { 0, 4000, NONE, 10000, 32 },
 };
 
+// array of possible configurations for the whole analysis - placeholder for web app config
 AnalysisConfig exampleConfigs[3] = {
   {
     280,    // noise floor
@@ -39,7 +40,7 @@ AnalysisConfig exampleConfigs[3] = {
     1,
     {
       &exampleMajorPeaksConfigs[2],
-      &exampleMajorPeaksConfigs[3],
+      &exampleMajorPeaksConfigs[2],
     }
   }
 };
@@ -48,6 +49,7 @@ AnalysisConfig loadedConfig = exampleConfigs[0];
 
 VibrosonicsAPI vapi = VibrosonicsAPI();
 
+// bool to keep track of when past configs are no longer valid
 bool dirty = false;
 
 float windowData[WINDOW_SIZE_BY_2] = { 0 };
@@ -58,8 +60,9 @@ float melodicData[WINDOW_SIZE_BY_2] = { 0 };
 Spectrogram melodicSpectrogram = Spectrogram(2, WINDOW_SIZE_OVERLAP);
 ModuleGroup melodic = ModuleGroup(&melodicSpectrogram);
 
-// NOTE: using float** for the type here is going to cause issues when adding percussion - find more elegant solution
-ModuleInterface<float**>* analysisModules[NUM_OUT_CH] = { nullptr };
+// array of modules being used - current length is NUM_OUT_CH as we only support 1 module
+// per output at the moment
+AnalysisModule* analysisModules[NUM_OUT_CH] = { nullptr };
 
 void setup() {
   Serial.begin(115200);
@@ -130,9 +133,12 @@ void loop() {
   // have analysis modules analyze the frequency domain data
   melodic.runAnalysis();
 
+  // loop to get and synthesize results for each analysis module
   for (int i = 0; i < NUM_OUT_CH; i++){
     if (loadedConfig.modules[i]->moduleType == MAJORPEAKS){
-      float **analysisData = analysisModules[i]->getOutput();
+      // for major peaks modules, we can cast as ModuleInterface<float**>*
+      ModuleInterface<float**>* mpModuleInterface = static_cast<ModuleInterface<float**>*>(analysisModules[i]);
+      float **analysisData = mpModuleInterface->getOutput();
       synthesizePeak(i, analysisData[MP_FREQ][0], analysisData[MP_AMP][0], loadedConfig.modules[i]->freqLow, loadedConfig.modules[i]->freqHigh, loadedConfig.modules[i]->frequencyMapping);
       AudioLab.mapAmplitudes(i, loadedConfig.modules[i]->minAmpNorm);
     }

--- a/src/Configurable/Configurable.ino
+++ b/src/Configurable/Configurable.ino
@@ -4,17 +4,17 @@
 MajorPeaksConfig exampleMajorPeaksConfigs[4] = {
   { 400, 1000, OCTAVE, 10000, 1 },
   { 1000, 3600, OCTAVE, 10000, 1 },
-  { 0, 3600, NONE, 10000, 32 },
-  { 0, 3600, NONE, 10000, 1 },
+  { 0, 4000, NONE, 10000, 32 },
+  { 0, 4000, NONE, 10000, 32 },
 };
 
 AnalysisConfig exampleConfigs[3] = {
   {
-    280,
-    6,
-    1,
-    1.4,
-    0.4,
+    280,    // noise floor
+    6,      // cfar number of reference cells
+    1,      // cfar number of guard cells
+    1.4,    // cfar bias
+    0.2,    // smoothing factor 
     {
       &exampleMajorPeaksConfigs[0],
       &exampleMajorPeaksConfigs[1],
@@ -25,18 +25,18 @@ AnalysisConfig exampleConfigs[3] = {
     6,
     1,
     1.4,
-    0.4,
+    0.2,
     {
       &exampleMajorPeaksConfigs[1],
       &exampleMajorPeaksConfigs[0],
     }
   },
   {
-    280,
+    100,
     6,
     1,
     1.4,
-    0.4,
+    1,
     {
       &exampleMajorPeaksConfigs[2],
       &exampleMajorPeaksConfigs[3],
@@ -87,14 +87,9 @@ void loop() {
 
   // if output modules have changed since last window, need to reassign outputs
   if (dirty == true) {
-    melodic.clearModules();
-    // delete old modules
-    for (int i = 0; i < NUM_OUT_CH; i++) {
-      if (modules[i] != nullptr){
-        delete modules[i];
-        modules[i] = nullptr;
-      }
-    }
+    // delete old output modules
+    clearOutputModules();
+
     // reassign modules to outputs
     assignOutputModules();
 
@@ -145,6 +140,17 @@ void loop() {
 
   // synthesize the waves created
   AudioLab.synthesize();
+}
+
+void clearOutputModules(){
+  melodic.clearModules();
+  // delete old modules
+  for (int i = 0; i < NUM_OUT_CH; i++) {
+    if (modules[i] != nullptr){
+      delete modules[i];
+      modules[i] = nullptr;
+    }
+  }
 }
 
 void assignOutputModules(){

--- a/src/Configurable/Configurable.ino
+++ b/src/Configurable/Configurable.ino
@@ -1,0 +1,130 @@
+#include "VibrosonicsAPI.h"
+#include "storage.h"
+
+#define MID_FREQ_LO 400
+#define MID_FREQ_HI 1000
+#define HIGH_FREQ_LO 1000
+#define HIGH_FREQ_HI 3600
+
+AnalysisConfig loaded_config;
+
+VibrosonicsAPI vapi = VibrosonicsAPI();
+
+float windowData[WINDOW_SIZE_BY_2] = { 0 };
+float filteredData[WINDOW_SIZE_BY_2] = { 0 };
+float smoothedData[WINDOW_SIZE_BY_2] = { 0 };
+float melodicData[WINDOW_SIZE_BY_2] = { 0 };
+
+Spectrogram melodicSpectrogram = Spectrogram(2, WINDOW_SIZE_OVERLAP);
+ModuleGroup melodic = ModuleGroup(&melodicSpectrogram);
+MajorPeaks midPeak = MajorPeaks(1);
+MajorPeaks highPeak = MajorPeaks(1);
+
+void setup() {
+  Serial.begin(115200);
+
+  // call the API setup function
+  vapi.init();
+
+  midPeak.setWindowSize(WINDOW_SIZE_OVERLAP);
+  highPeak.setWindowSize(WINDOW_SIZE_OVERLAP);
+
+  // add melody peak modules to the melodic group
+  melodic.addModule(&midPeak, MID_FREQ_LO, MID_FREQ_HI);
+  melodic.addModule(&highPeak, HIGH_FREQ_LO, HIGH_FREQ_HI);
+}
+
+void loop() {
+  // skip if new audio window has not been recorded
+  if (!vapi.isAudioLabReady()) {
+    return;
+  }
+
+  // process the raw audio signal into frequency domain data
+  vapi.processAudioInput(windowData);
+
+  // process the freqeuncy domain data
+
+  // floor the noise from the wire using a set threshold
+  vapi.noiseFloor(windowData, loaded_config.noiseFloor);
+
+  // copy the windowData to filterdData
+  memcpy(filteredData, windowData, WINDOW_SIZE_BY_2 * sizeof(float));
+
+  // apply CFAR to filter the data
+  vapi.noiseFloorCFAR(filteredData, loaded_config.cfarRefCount, loaded_config.cfarGuardCount, loaded_config.cfarBias);
+
+  // smooth the filtered data over a long and short period of time
+  AudioPrism::smooth_window_over_time(filteredData, smoothedData, loaded_config.smoothingFactor, WINDOW_SIZE_OVERLAP);
+
+  // calculate the percussive and melodic data
+  for (int i = 0; i < WINDOW_SIZE_BY_2; i++) {
+    // the smoothedData value is usually less than windowData's, but in the
+    // case that windowData dropped quickly (becomes less than the
+    // smoothedData) we want to adapt to that
+    melodicData[i] = min(windowData[i], smoothedData[i]);
+    if (melodicData[i] < loaded_config.noiseFloor) {
+      melodicData[i] = 0.;
+    }
+  }
+
+  // push the short smoothed data for the melodic peak detection
+  melodicSpectrogram.pushWindow(melodicData);
+
+  // have analysis modules analyze the frequency domain data
+  melodic.runAnalysis();
+
+  float **midPeakData = midPeak.getOutput();
+  float **highPeakData = highPeak.getOutput();
+
+  // synthesize the mid peak to the left speaker, ignoring percussion
+  synthesizePeak(0, midPeakData[MP_FREQ][0], midPeakData[MP_AMP][0], MID_FREQ_LO, MID_FREQ_HI);
+
+  // synthesize the high peak to the right speaker, ducking with percussive
+  // hits
+  synthesizePeak(1, highPeakData[MP_FREQ][0], highPeakData[MP_AMP][0], HIGH_FREQ_LO, HIGH_FREQ_HI);
+
+  // map the amplitudes of waves in both channels
+  AudioLab.mapAmplitudes(0, 10000);
+  AudioLab.mapAmplitudes(1, 10000);
+
+  // synthesize the waves created
+  AudioLab.synthesize();
+
+  // AudioLab.printWaves();
+}
+
+int interpolateAroundPeak(float *data, int indexOfPeak) {
+  float prePeak = indexOfPeak == 0 ? 0.0 : data[indexOfPeak - 1];
+  float atPeak = data[indexOfPeak];
+  float postPeak = indexOfPeak == WINDOW_SIZE_BY_2 ? 0.0 : data[indexOfPeak + 1];
+  // summing around the index of maximum amplitude to normalize magnitudeOfChange
+  float peakSum = prePeak + atPeak + postPeak;
+  // interpolating the direction and magnitude of change, and normalizing from -1.0 to 1.0
+  float magnitudeOfChange = ((atPeak + postPeak) - (atPeak + prePeak)) / (peakSum > 0.0 ? peakSum : 1.0);
+
+  // return interpolated frequency
+  return int(round((float(indexOfPeak) + magnitudeOfChange) * FREQ_RES));
+}
+
+void synthesizePeak(int channel, float freq, float amp, float freqMin, float freqMax) {
+  // interpolate the frequency around the peak to get a more accurate measure
+  float interp_freq = interpolateAroundPeak(windowData, int(round(freq * FREQ_WIDTH)));
+
+  // map the frequency to the haptic range by dividing it by 2 (transposing by
+  // octaves) until it is below 230Hz. This is why 3600Hz is a better max
+  // frequency than 3800Hz+ since we can divide one less time and the output is
+  // closer to the full haptic range.
+  float haptic_freq = interp_freq;
+  if (loaded_config.frequencyMapping == OCTAVE)
+  {
+    haptic_freq = vapi.mapFrequencyByOctaves(interp_freq, freqMax);
+  }
+  else if (loaded_config.frequencyMapping == MIDI)
+  {
+    haptic_freq = vapi.mapFrequencyMIDI(interp_freq, freqMin, freqMax);
+  }
+
+  // create the wave
+  vapi.assignWave(haptic_freq, amp, channel);
+}

--- a/src/Configurable/Configurable.ino
+++ b/src/Configurable/Configurable.ino
@@ -1,6 +1,13 @@
 #include "VibrosonicsAPI.h"
 #include "storage.h"
 
+MajorPeaksConfig exampleMajorPeaksConfigs[4] = {
+  { 400, 1000, OCTAVE, 10000, 1 },
+  { 1000, 3600, OCTAVE, 10000, 1 },
+  { 0, 3600, NONE, 10000, 32 },
+  { 0, 3600, NONE, 10000, 1 },
+};
+
 AnalysisConfig exampleConfigs[3] = {
   {
     280,
@@ -9,20 +16,8 @@ AnalysisConfig exampleConfigs[3] = {
     1.4,
     0.4,
     {
-      {
-        MAJORPEAKS,
-        400,
-        1000,
-        OCTAVE,
-        10000
-      },
-      {
-        MAJORPEAKS,
-        1000,
-        3600,
-        OCTAVE,
-        10000
-      },
+      &exampleMajorPeaksConfigs[0],
+      &exampleMajorPeaksConfigs[1],
     }
   },
   {
@@ -32,20 +27,8 @@ AnalysisConfig exampleConfigs[3] = {
     1.4,
     0.4,
     {
-      {
-        MAJORPEAKS,
-        1000,
-        3600,
-        OCTAVE,
-        10000
-      },
-      {
-        MAJORPEAKS,
-        400,
-        1000,
-        OCTAVE,
-        10000
-      }
+      &exampleMajorPeaksConfigs[1],
+      &exampleMajorPeaksConfigs[0],
     }
   },
   {
@@ -55,22 +38,10 @@ AnalysisConfig exampleConfigs[3] = {
     1.4,
     0.4,
     {
-      {
-        MAJORPEAKS,
-        400,
-        1000,
-        NONE,
-        10000
-      },
-      {
-        MAJORPEAKS,
-        1000,
-        3600,
-        NONE,
-        10000
-      },
+      &exampleMajorPeaksConfigs[2],
+      &exampleMajorPeaksConfigs[3],
     }
-  },
+  }
 };
 
 AnalysisConfig loadedConfig = exampleConfigs[0];
@@ -106,9 +77,6 @@ void loop() {
     if (exampleToLoad >= 1 && exampleToLoad <= 3) {
       loadedConfig = exampleConfigs[exampleToLoad - 1];
       dirty = true;
-    }
-    else{
-      Serial.print("out of example range");
     }
   }
 
@@ -168,10 +136,10 @@ void loop() {
   melodic.runAnalysis();
 
   for (int i = 0; i < NUM_OUT_CH; i++){
-    if (loadedConfig.outputs[i].moduleType != EMPTY){
+    if (loadedConfig.outputs[i]->moduleType == MAJORPEAKS){
       float **analysisData = modules[i]->getOutput();
-      synthesizePeak(i, analysisData[MP_FREQ][0], analysisData[MP_AMP][0], loadedConfig.outputs[i].freqLow, loadedConfig.outputs[i].freqHigh, loadedConfig.outputs[i].frequencyMapping);
-      AudioLab.mapAmplitudes(i, loadedConfig.outputs[i].minAmpNorm);
+      synthesizePeak(i, analysisData[MP_FREQ][0], analysisData[MP_AMP][0], loadedConfig.outputs[i]->freqLow, loadedConfig.outputs[i]->freqHigh, loadedConfig.outputs[i]->frequencyMapping);
+      AudioLab.mapAmplitudes(i, loadedConfig.outputs[i]->minAmpNorm);
     }
   }
 
@@ -181,10 +149,11 @@ void loop() {
 
 void assignOutputModules(){
   for (int i = 0; i < NUM_OUT_CH; i++){
-    if (loadedConfig.outputs[i].moduleType == MAJORPEAKS){
-      modules[i] = new MajorPeaks(1);
+    if (loadedConfig.outputs[i]->moduleType == MAJORPEAKS){
+      MajorPeaksConfig* majorPeaks = static_cast<MajorPeaksConfig*>(loadedConfig.outputs[i]);
+      modules[i] = new MajorPeaks(majorPeaks->maxPeaks);
       modules[i]->setWindowSize(WINDOW_SIZE_OVERLAP);
-      melodic.addModule(modules[i], loadedConfig.outputs[i].freqLow, loadedConfig.outputs[i].freqHigh);
+      melodic.addModule(modules[i], loadedConfig.outputs[i]->freqLow, loadedConfig.outputs[i]->freqHigh);
     }
   }
 }
@@ -206,10 +175,6 @@ void synthesizePeak(int channel, float freq, float amp, float freqMin, float fre
   // interpolate the frequency around the peak to get a more accurate measure
   float interp_freq = interpolateAroundPeak(windowData, int(round(freq * FREQ_WIDTH)));
 
-  // map the frequency to the haptic range by dividing it by 2 (transposing by
-  // octaves) until it is below 230Hz. This is why 3600Hz is a better max
-  // frequency than 3800Hz+ since we can divide one less time and the output is
-  // closer to the full haptic range.
   float haptic_freq = interp_freq;
   if (mappingOption == OCTAVE)
   {

--- a/src/Configurable/Configurable.ino
+++ b/src/Configurable/Configurable.ino
@@ -1,12 +1,29 @@
 #include "VibrosonicsAPI.h"
 #include "storage.h"
 
-#define MID_FREQ_LO 400
-#define MID_FREQ_HI 1000
-#define HIGH_FREQ_LO 1000
-#define HIGH_FREQ_HI 3600
-
-AnalysisConfig loaded_config;
+AnalysisConfig loadedConfig = {
+  280,
+  6,
+  1,
+  1.4,
+  0.4,
+  {
+    {
+      EMPTY,
+      400,
+      1000,
+      OCTAVE,
+      10000
+    },
+    {
+      MAJORPEAKS,
+      1000,
+      3600,
+      OCTAVE,
+      10000
+    },
+  }
+};
 
 VibrosonicsAPI vapi = VibrosonicsAPI();
 
@@ -17,8 +34,9 @@ float melodicData[WINDOW_SIZE_BY_2] = { 0 };
 
 Spectrogram melodicSpectrogram = Spectrogram(2, WINDOW_SIZE_OVERLAP);
 ModuleGroup melodic = ModuleGroup(&melodicSpectrogram);
-MajorPeaks midPeak = MajorPeaks(1);
-MajorPeaks highPeak = MajorPeaks(1);
+
+// NOTE: using float** for the type here is going to cause issues when adding percussion - find more elegant solution
+ModuleInterface<float**>* modules[NUM_OUT_CH];
 
 void setup() {
   Serial.begin(115200);
@@ -26,12 +44,13 @@ void setup() {
   // call the API setup function
   vapi.init();
 
-  midPeak.setWindowSize(WINDOW_SIZE_OVERLAP);
-  highPeak.setWindowSize(WINDOW_SIZE_OVERLAP);
-
-  // add melody peak modules to the melodic group
-  melodic.addModule(&midPeak, MID_FREQ_LO, MID_FREQ_HI);
-  melodic.addModule(&highPeak, HIGH_FREQ_LO, HIGH_FREQ_HI);
+  for (int i = 0; i < NUM_OUT_CH; i++){
+    if (loadedConfig.outputs[i].moduleType == MAJORPEAKS){
+      modules[i] = new MajorPeaks(1);
+      modules[i]->setWindowSize(WINDOW_SIZE_OVERLAP);
+      melodic.addModule(modules[i], loadedConfig.outputs[i].freqLow, loadedConfig.outputs[i].freqHigh);
+    }
+  }
 }
 
 void loop() {
@@ -46,16 +65,16 @@ void loop() {
   // process the freqeuncy domain data
 
   // floor the noise from the wire using a set threshold
-  vapi.noiseFloor(windowData, loaded_config.noiseFloor);
+  vapi.noiseFloor(windowData, loadedConfig.noiseFloor);
 
   // copy the windowData to filterdData
   memcpy(filteredData, windowData, WINDOW_SIZE_BY_2 * sizeof(float));
 
   // apply CFAR to filter the data
-  vapi.noiseFloorCFAR(filteredData, loaded_config.cfarRefCount, loaded_config.cfarGuardCount, loaded_config.cfarBias);
+  vapi.noiseFloorCFAR(filteredData, loadedConfig.cfarRefCount, loadedConfig.cfarGuardCount, loadedConfig.cfarBias);
 
   // smooth the filtered data over a long and short period of time
-  AudioPrism::smooth_window_over_time(filteredData, smoothedData, loaded_config.smoothingFactor, WINDOW_SIZE_OVERLAP);
+  AudioPrism::smooth_window_over_time(filteredData, smoothedData, loadedConfig.smoothingFactor, WINDOW_SIZE_OVERLAP);
 
   // calculate the percussive and melodic data
   for (int i = 0; i < WINDOW_SIZE_BY_2; i++) {
@@ -63,7 +82,7 @@ void loop() {
     // case that windowData dropped quickly (becomes less than the
     // smoothedData) we want to adapt to that
     melodicData[i] = min(windowData[i], smoothedData[i]);
-    if (melodicData[i] < loaded_config.noiseFloor) {
+    if (melodicData[i] < loadedConfig.noiseFloor) {
       melodicData[i] = 0.;
     }
   }
@@ -74,24 +93,16 @@ void loop() {
   // have analysis modules analyze the frequency domain data
   melodic.runAnalysis();
 
-  float **midPeakData = midPeak.getOutput();
-  float **highPeakData = highPeak.getOutput();
-
-  // synthesize the mid peak to the left speaker, ignoring percussion
-  synthesizePeak(0, midPeakData[MP_FREQ][0], midPeakData[MP_AMP][0], MID_FREQ_LO, MID_FREQ_HI);
-
-  // synthesize the high peak to the right speaker, ducking with percussive
-  // hits
-  synthesizePeak(1, highPeakData[MP_FREQ][0], highPeakData[MP_AMP][0], HIGH_FREQ_LO, HIGH_FREQ_HI);
-
-  // map the amplitudes of waves in both channels
-  AudioLab.mapAmplitudes(0, 10000);
-  AudioLab.mapAmplitudes(1, 10000);
+  for (int i = 0; i < NUM_OUT_CH; i++){
+    if (loadedConfig.outputs[i].moduleType != EMPTY){
+      float **analysisData = modules[i]->getOutput();
+      synthesizePeak(i, analysisData[MP_FREQ][0], analysisData[MP_AMP][0], loadedConfig.outputs[i].freqLow, loadedConfig.outputs[i].freqHigh, loadedConfig.outputs[i].frequencyMapping);
+      AudioLab.mapAmplitudes(i, loadedConfig.outputs[i].minAmpNorm);
+    }
+  }
 
   // synthesize the waves created
   AudioLab.synthesize();
-
-  // AudioLab.printWaves();
 }
 
 int interpolateAroundPeak(float *data, int indexOfPeak) {
@@ -107,7 +118,7 @@ int interpolateAroundPeak(float *data, int indexOfPeak) {
   return int(round((float(indexOfPeak) + magnitudeOfChange) * FREQ_RES));
 }
 
-void synthesizePeak(int channel, float freq, float amp, float freqMin, float freqMax) {
+void synthesizePeak(int channel, float freq, float amp, float freqMin, float freqMax, FrequencyMapping mappingOption) {
   // interpolate the frequency around the peak to get a more accurate measure
   float interp_freq = interpolateAroundPeak(windowData, int(round(freq * FREQ_WIDTH)));
 
@@ -116,11 +127,11 @@ void synthesizePeak(int channel, float freq, float amp, float freqMin, float fre
   // frequency than 3800Hz+ since we can divide one less time and the output is
   // closer to the full haptic range.
   float haptic_freq = interp_freq;
-  if (loaded_config.frequencyMapping == OCTAVE)
+  if (mappingOption == OCTAVE)
   {
     haptic_freq = vapi.mapFrequencyByOctaves(interp_freq, freqMax);
   }
-  else if (loaded_config.frequencyMapping == MIDI)
+  else if (mappingOption == MIDI)
   {
     haptic_freq = vapi.mapFrequencyMIDI(interp_freq, freqMin, freqMax);
   }

--- a/src/Configurable/Configurable.ino
+++ b/src/Configurable/Configurable.ino
@@ -1,31 +1,83 @@
 #include "VibrosonicsAPI.h"
 #include "storage.h"
 
-AnalysisConfig loadedConfig = {
-  280,
-  6,
-  1,
-  1.4,
-  0.4,
+AnalysisConfig exampleConfigs[3] = {
   {
+    280,
+    6,
+    1,
+    1.4,
+    0.4,
     {
-      EMPTY,
-      400,
-      1000,
-      OCTAVE,
-      10000
-    },
+      {
+        MAJORPEAKS,
+        400,
+        1000,
+        OCTAVE,
+        10000
+      },
+      {
+        MAJORPEAKS,
+        1000,
+        3600,
+        OCTAVE,
+        10000
+      },
+    }
+  },
+  {
+    280,
+    6,
+    1,
+    1.4,
+    0.4,
     {
-      MAJORPEAKS,
-      1000,
-      3600,
-      OCTAVE,
-      10000
-    },
-  }
+      {
+        MAJORPEAKS,
+        1000,
+        3600,
+        OCTAVE,
+        10000
+      },
+      {
+        MAJORPEAKS,
+        400,
+        1000,
+        OCTAVE,
+        10000
+      }
+    }
+  },
+  {
+    280,
+    6,
+    1,
+    1.4,
+    0.4,
+    {
+      {
+        MAJORPEAKS,
+        400,
+        1000,
+        NONE,
+        10000
+      },
+      {
+        MAJORPEAKS,
+        1000,
+        3600,
+        NONE,
+        10000
+      },
+    }
+  },
 };
 
+AnalysisConfig loadedConfig = exampleConfigs[0];
+
 VibrosonicsAPI vapi = VibrosonicsAPI();
+
+bool dirty = false;
 
 float windowData[WINDOW_SIZE_BY_2] = { 0 };
 float filteredData[WINDOW_SIZE_BY_2] = { 0 };
@@ -36,7 +88,7 @@ Spectrogram melodicSpectrogram = Spectrogram(2, WINDOW_SIZE_OVERLAP);
 ModuleGroup melodic = ModuleGroup(&melodicSpectrogram);
 
 // NOTE: using float** for the type here is going to cause issues when adding percussion - find more elegant solution
-ModuleInterface<float**>* modules[NUM_OUT_CH];
+ModuleInterface<float**>* modules[NUM_OUT_CH] = { nullptr };
 
 void setup() {
   Serial.begin(115200);
@@ -44,19 +96,41 @@ void setup() {
   // call the API setup function
   vapi.init();
 
-  for (int i = 0; i < NUM_OUT_CH; i++){
-    if (loadedConfig.outputs[i].moduleType == MAJORPEAKS){
-      modules[i] = new MajorPeaks(1);
-      modules[i]->setWindowSize(WINDOW_SIZE_OVERLAP);
-      melodic.addModule(modules[i], loadedConfig.outputs[i].freqLow, loadedConfig.outputs[i].freqHigh);
-    }
-  }
+  assignOutputModules();
 }
 
 void loop() {
+  // NOTE: this is a placeholder for the web app configuration and will be deleted in the future
+  if (Serial.available() > 0) {
+    int exampleToLoad = Serial.parseInt();
+    if (exampleToLoad >= 1 && exampleToLoad <= 3) {
+      loadedConfig = exampleConfigs[exampleToLoad - 1];
+      dirty = true;
+    }
+    else{
+      Serial.print("out of example range");
+    }
+  }
+
   // skip if new audio window has not been recorded
   if (!vapi.isAudioLabReady()) {
     return;
+  }
+
+  // if output modules have changed since last window, need to reassign outputs
+  if (dirty == true) {
+    melodic.clearModules();
+    // delete old modules
+    for (int i = 0; i < NUM_OUT_CH; i++) {
+      if (modules[i] != nullptr){
+        delete modules[i];
+        modules[i] = nullptr;
+      }
+    }
+    // reassign modules to outputs
+    assignOutputModules();
+
+    dirty = false;
   }
 
   // process the raw audio signal into frequency domain data
@@ -103,6 +177,16 @@ void loop() {
 
   // synthesize the waves created
   AudioLab.synthesize();
+}
+
+void assignOutputModules(){
+  for (int i = 0; i < NUM_OUT_CH; i++){
+    if (loadedConfig.outputs[i].moduleType == MAJORPEAKS){
+      modules[i] = new MajorPeaks(1);
+      modules[i]->setWindowSize(WINDOW_SIZE_OVERLAP);
+      melodic.addModule(modules[i], loadedConfig.outputs[i].freqLow, loadedConfig.outputs[i].freqHigh);
+    }
+  }
 }
 
 int interpolateAroundPeak(float *data, int indexOfPeak) {

--- a/src/Configurable/storage.h
+++ b/src/Configurable/storage.h
@@ -16,21 +16,45 @@ enum ModuleType{
   PERCUSSION
 };
 
-typedef struct {
+struct OutputConfig {
+  virtual ~OutputConfig() = default;
+  OutputConfig(ModuleType moduleType,
+               uint16_t freqLow,
+               uint16_t freqHigh,
+               FrequencyMapping frequencyMapping,
+               float minAmpNorm)
+    : moduleType(moduleType),
+      freqLow(freqLow),
+      freqHigh(freqHigh),
+      frequencyMapping(frequencyMapping),
+      minAmpNorm(minAmpNorm) {}
   ModuleType moduleType = EMPTY;
   uint16_t freqLow;
   uint16_t freqHigh;
   FrequencyMapping frequencyMapping;
   float minAmpNorm;
-} OutputConfig;
+};
 
-typedef struct {
+struct MajorPeaksConfig : OutputConfig {
+  MajorPeaksConfig(uint16_t freqLow,
+                   uint16_t freqHigh,
+                   FrequencyMapping frequencyMapping,
+                   float minAmpNorm,
+                   int maxPeaks)
+    : OutputConfig(MAJORPEAKS, freqLow, freqHigh, frequencyMapping, minAmpNorm),
+      maxPeaks(maxPeaks) {}
+  int maxPeaks;
+};
+
+// TODO: add percussion config as a child of OutputConfig
+
+struct AnalysisConfig {
   float noiseFloor = 280;
   uint16_t cfarRefCount = 6;
   uint16_t cfarGuardCount = 1;
   float cfarBias = 1.4;
   float smoothingFactor = 0.3;
-  OutputConfig outputs[NUM_OUT_CH];
-} AnalysisConfig;
+  OutputConfig* outputs[NUM_OUT_CH];
+} ;
 
 #endif

--- a/src/Configurable/storage.h
+++ b/src/Configurable/storage.h
@@ -1,3 +1,14 @@
+/***************************************************************
+ * FILE: storage.h
+ * 
+ * DATE: 2/12/2026
+ * 
+ * DESCRIPTION: This namespace contains structs and enums needed
+ * to store analysis configurations for Configurable.ino
+ * 
+ * AUTHOR: Danielle Chang
+ ***************************************************************/
+
 #ifndef STORAGE_H
 #define STORAGE_H
 
@@ -15,7 +26,8 @@ enum ModuleType{
   PERCUSSION
 };
 
-// configuration for a single analysis module
+// configuration for a single analysis module. constructor is protected as we only
+// want to instantiate derived structs
 struct ModuleConfig {
   virtual ~ModuleConfig() = default;
 protected:

--- a/src/Configurable/storage.h
+++ b/src/Configurable/storage.h
@@ -42,10 +42,15 @@ protected:
       frequencyMapping(frequencyMapping),
       minAmpNorm(minAmpNorm) {}
 public:
+  // type of the analysis module. see ModuleType enum for options
   const ModuleType moduleType;
+  // low value of the frequency range to pick up. must be positive 
   uint16_t freqLow;
+  // high value of the frequency range to pick up. must be positive and should be larger than freqLow
   uint16_t freqHigh;
+  // what type of frequency mapping to use. see FrequencyMapping enum for options
   FrequencyMapping frequencyMapping;
+  // minimum value to use for amplitude mapping. must be positive
   float minAmpNorm;
 };
 
@@ -58,6 +63,7 @@ struct MajorPeaksConfig : ModuleConfig {
                    int maxPeaks)
     : ModuleConfig(MAJORPEAKS, freqLow, freqHigh, frequencyMapping, minAmpNorm),
       maxPeaks(maxPeaks) {}
+  // number of peaks to pick up in analysis. minimum of 1
   int maxPeaks;
 };
 
@@ -65,10 +71,15 @@ struct MajorPeaksConfig : ModuleConfig {
 
 // configuration for our entire analysis
 struct AnalysisConfig {
+  // frequency to use for the noise floor. minimum of 0
   float noiseFloor = 280;
+  // number of reference cells to use for CFAR noise cancellation. minimum of 1
   uint16_t cfarRefCount = 6;
+  // number of guard cells to use for CFAR noise cancellation algorithm. minimum of 1
   uint16_t cfarGuardCount = 1;
+  // bias to use for CFAR noise cancellation algorithm. minimum of 0 (no CFAR)
   float cfarBias = 1.4;
+  // smoothing factor for smooth_window_over_time. value from 0-1 (0 high smoothing, 1 no smoothing)
   float smoothingFactor = 0.3;
   ModuleConfig* modules[NUM_OUT_CH];
 } ;

--- a/src/Configurable/storage.h
+++ b/src/Configurable/storage.h
@@ -9,19 +9,27 @@ enum FrequencyMapping{
   MIDI
 };
 
+// note: add more and update sketch as more support is added
+enum ModuleType{
+  EMPTY,
+  MAJORPEAKS,
+  PERCUSSION
+};
+
 typedef struct {
-  uint8_t freqLow;
-  uint8_t freqHigh;
+  ModuleType moduleType = EMPTY;
+  uint16_t freqLow;
+  uint16_t freqHigh;
+  FrequencyMapping frequencyMapping;
   float minAmpNorm;
 } OutputConfig;
 
 typedef struct {
-  float noiseFloor = 0;
-  uint8_t cfarRefCount = 6;
-  uint8_t cfarGuardCount = 1;
+  float noiseFloor = 280;
+  uint16_t cfarRefCount = 6;
+  uint16_t cfarGuardCount = 1;
   float cfarBias = 1.4;
   float smoothingFactor = 0.3;
-  FrequencyMapping frequencyMapping = OCTAVE;
   OutputConfig outputs[NUM_OUT_CH];
 } AnalysisConfig;
 

--- a/src/Configurable/storage.h
+++ b/src/Configurable/storage.h
@@ -1,0 +1,28 @@
+#ifndef STORAGE_H
+#define STORAGE_H
+
+#include <AudioLab.h>
+
+enum FrequencyMapping{
+  NONE,
+  OCTAVE,
+  MIDI
+};
+
+typedef struct {
+  uint8_t freqLow;
+  uint8_t freqHigh;
+  float minAmpNorm;
+} OutputConfig;
+
+typedef struct {
+  float noiseFloor = 0;
+  uint8_t cfarRefCount = 6;
+  uint8_t cfarGuardCount = 1;
+  float cfarBias = 1.4;
+  float smoothingFactor = 0.3;
+  FrequencyMapping frequencyMapping = OCTAVE;
+  OutputConfig outputs[NUM_OUT_CH];
+} AnalysisConfig;
+
+#endif

--- a/src/Configurable/storage.h
+++ b/src/Configurable/storage.h
@@ -11,14 +11,15 @@ enum FrequencyMapping{
 
 // note: add more and update sketch as more support is added
 enum ModuleType{
-  EMPTY,
   MAJORPEAKS,
   PERCUSSION
 };
 
-struct OutputConfig {
-  virtual ~OutputConfig() = default;
-  OutputConfig(ModuleType moduleType,
+// configuration for a single analysis module
+struct ModuleConfig {
+  virtual ~ModuleConfig() = default;
+protected:
+  ModuleConfig(ModuleType moduleType,
                uint16_t freqLow,
                uint16_t freqHigh,
                FrequencyMapping frequencyMapping,
@@ -28,33 +29,36 @@ struct OutputConfig {
       freqHigh(freqHigh),
       frequencyMapping(frequencyMapping),
       minAmpNorm(minAmpNorm) {}
-  ModuleType moduleType = EMPTY;
+public:
+  const ModuleType moduleType;
   uint16_t freqLow;
   uint16_t freqHigh;
   FrequencyMapping frequencyMapping;
   float minAmpNorm;
 };
 
-struct MajorPeaksConfig : OutputConfig {
+// configuration unique to the major peaks analysis module
+struct MajorPeaksConfig : ModuleConfig {
   MajorPeaksConfig(uint16_t freqLow,
                    uint16_t freqHigh,
                    FrequencyMapping frequencyMapping,
                    float minAmpNorm,
                    int maxPeaks)
-    : OutputConfig(MAJORPEAKS, freqLow, freqHigh, frequencyMapping, minAmpNorm),
+    : ModuleConfig(MAJORPEAKS, freqLow, freqHigh, frequencyMapping, minAmpNorm),
       maxPeaks(maxPeaks) {}
   int maxPeaks;
 };
 
-// TODO: add percussion config as a child of OutputConfig
+// TODO: add percussion config as a child of ModuleConfig
 
+// configuration for our entire analysis
 struct AnalysisConfig {
   float noiseFloor = 280;
   uint16_t cfarRefCount = 6;
   uint16_t cfarGuardCount = 1;
   float cfarBias = 1.4;
   float smoothingFactor = 0.3;
-  OutputConfig* outputs[NUM_OUT_CH];
+  ModuleConfig* modules[NUM_OUT_CH];
 } ;
 
 #endif


### PR DESCRIPTION
Adds Configurable.ino, a sketch that allows for dynamic configuration of global and per-output analysis parameters through the serial monitor. Currently only configures major peaks modules, but implementation should be mostly scalable to percussion. The following parameters are adjustable:

Global (affects all outputs):
- Noise floor
- CFAR noise cancellation params (ref count, guard count, bias)
- Smoothing factor

Per-Module:
- Module type
- Low frequency
- High frequency
- Frequency mapping type (midi, octave, or none)
- Min amplitude normalization value

Major Peaks:
- Max number of peaks

These values are stored in a struct defined in storage.h. In the future, this struct will be changed by API calls made through the web app.