### PR TITLE
Feat/realtimeUpdates

### DIFF
--- a/WebApp/src/components/analysisModule.jsx
+++ b/WebApp/src/components/analysisModule.jsx
@@ -55,6 +55,8 @@ export default function AnalysisModule({ index, module, setModules }) {
     // Update the UI
     setModules((prev) => {
       const updated = [...prev];
+
+      // This index is for the UI and may not be same for the web server
       updated[index] = {
         ...updated[index],
         [id]: val,
@@ -63,6 +65,7 @@ export default function AnalysisModule({ index, module, setModules }) {
     });
     // Send the updated val to the web server
     editSetting({
+      // This index is for the position in the web server array
       index: module.index,
       field: CONFIG_FIELDS[id],
       value: val
@@ -103,14 +106,13 @@ export default function AnalysisModule({ index, module, setModules }) {
       <h3 className="font-bold text-lg">
         Module: {MODULE_TYPE[module.moduleType]}
       </h3>
-      <h3 className="font-bold text-lg">TODO: Index {index}</h3>
 
       {/* TODO: this is some logic saying ranges are not valid, add some sort of handling here */}
       <div>
         {isValid?.current ? (
-          <div>TODO: Valid ranges</div>
+          <div>Valid ranges</div>
         ) : (
-          <div className="font-bold text-red-500">TODO: Not valid ranges</div>
+          <div className="font-bold text-red-500">Not valid ranges</div>
         )}
       </div>
 

--- a/WebApp/src/components/analysisModule.jsx
+++ b/WebApp/src/components/analysisModule.jsx
@@ -8,10 +8,10 @@
  * Author: Ivan Wong and Bella Mann
  ***************************************************************/
 
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import Knob from "../atomics/knob";
 import ModuleDisplay from "../data/moduleDisplay.json";
-import { FREQUENCY_MAPPING, MODULE_TYPE, WAVE_TYPE } from "../utils/utils";
+import { FREQUENCY_MAPPING, MODULE_TYPE, useEditSetting, WAVE_TYPE, CONFIG_FIELDS, QUEUE_MESSAGE_ID } from "../utils/utils";
 
 /**
  * @brief The AnalysisModule component describe a full module that can be modified
@@ -24,7 +24,8 @@ import { FREQUENCY_MAPPING, MODULE_TYPE, WAVE_TYPE } from "../utils/utils";
  * @returns AnalysisModule component describing the configs
  */
 export default function AnalysisModule({ index, module, setModules }) {
-  const [isValid, setIsValid] = useState(true);
+  const isValid = useRef(true);
+  const { editSetting } = useEditSetting(QUEUE_MESSAGE_ID.EditModule, isValid);
 
   // Getting the module specific settings display values and ranges from the /data/ directory
   const settings = ModuleDisplay[module.moduleType].settings;
@@ -49,6 +50,7 @@ export default function AnalysisModule({ index, module, setModules }) {
    * @param {any} val - New value we want to set
    */
   const handleValueChange = (id, val) => {
+    // Update the UI
     setModules((prev) => {
       const updated = [...prev];
       updated[index] = {
@@ -57,6 +59,12 @@ export default function AnalysisModule({ index, module, setModules }) {
       };
       return updated;
     });
+    // Send the updated val to the web server
+    editSetting({
+      index: module.index,
+      field: CONFIG_FIELDS[id],
+      value: val
+    })
   };
 
   /**
@@ -66,12 +74,9 @@ export default function AnalysisModule({ index, module, setModules }) {
   useEffect(() => {
     const freqLow = module.freqLow;
     const freqHigh = module.freqHigh;
-    const isValidFreqRanges = (freqLow < freqHigh);
 
-    // Only update is value is flipped
-    if (isValidFreqRanges !== isValid) {
-      setIsValid(!isValid);
-    }
+    isValid.current = (freqLow <= freqHigh);
+
   }, [module.freqLow, module.freqHigh]);
 
   return (
@@ -83,7 +88,7 @@ export default function AnalysisModule({ index, module, setModules }) {
 
       {/* TODO: this is some logic saying ranges are not valid, add some sort of handling here */}
       <div>
-        {isValid? (
+        {isValid?.current ? (
           <div>TODO: Valid ranges</div>
         ) : (
           <div className="font-bold text-red-500">TODO: Not valid ranges</div>

--- a/WebApp/src/components/globalSettings.jsx
+++ b/WebApp/src/components/globalSettings.jsx
@@ -11,6 +11,7 @@
 
 import Knob from "../atomics/knob";
 import GlobalSettingsDisplay from "../data/globalSettingsDisplay.json";
+import { CONFIG_FIELDS, QUEUE_MESSAGE_ID, useEditSetting } from "../utils/utils";
 
 /**
  * @brief Displays the global configuration fields and updates them when changed
@@ -23,6 +24,9 @@ import GlobalSettingsDisplay from "../data/globalSettingsDisplay.json";
  */
 const GlobalSettings = ({ globalSettings, setGlobalSettings }) => {
   const settingsDisplay = GlobalSettingsDisplay.settings;
+
+  // Hook used for real-time updates
+  const { editSetting } = useEditSetting(QUEUE_MESSAGE_ID.EditGlobal);
  
   /**
    * @brief Handles the knob display when value is changed
@@ -31,7 +35,14 @@ const GlobalSettings = ({ globalSettings, setGlobalSettings }) => {
    * @param {Number} value - Internal number in the Knob component
    */
   const handleKnobChange = (id, value) => {
+    // Update the UI
     setGlobalSettings((prev) => ({ ...prev, [id]: value }));
+
+    // Send a HTTP req for the modified setting
+    editSetting({
+      field: CONFIG_FIELDS[id],
+      value: value
+    });
   };
 
   // Check if the settings exists/ were retrieved

--- a/WebApp/src/data/globalSettingsDisplay.json
+++ b/WebApp/src/data/globalSettingsDisplay.json
@@ -5,7 +5,7 @@
       "title": "Noise Floor",
       "description": "",
       "min": 0,
-      "max": 600,
+      "max": 2048,
       "step": 1
     },
     "smoothingFactor": {
@@ -19,21 +19,21 @@
       "title": "CFAR Reference Cells",
       "description": "",
       "min": 1,
-      "max": 25,
+      "max": 30,
       "step": 1
     },
     "cfarGuardCount": {
       "title": "CFAR Guard Cells",
       "description": "",
       "min": 1,
-      "max": 25,
+      "max": 30,
       "step": 1
     },
     "cfarBias": {
       "title": "CFAR Bias",
       "description": "",
       "min": 0,
-      "max": 10,
+      "max": 25,
       "step": 0.01
     },
     "minAmpNorm": {

--- a/WebApp/src/data/moduleDisplay.json
+++ b/WebApp/src/data/moduleDisplay.json
@@ -41,13 +41,13 @@
         "freqLow": {
           "title": "Low Cut Frequency",
           "min": 0,
-          "max": 20000,
+          "max": 4096,
           "step": 1
         },
         "freqHigh": {
           "title": "High Cut Frequency",
           "min": 0,
-          "max": 20000,
+          "max": 4096,
           "step": 1
         },
         "fluxThresh": {
@@ -59,7 +59,7 @@
         "energyThresh": {
           "title": "Energy Threshold",
           "min": 1,
-          "max": 50000000,
+          "max": 500000000,
           "step": 1
         },
         "entropyThresh": {

--- a/WebApp/src/utils/utils.js
+++ b/WebApp/src/utils/utils.js
@@ -9,10 +9,12 @@
  ***************************************************************/
 
 import axios from "axios";
+import { useCallback, useEffect, useRef } from "preact/hooks";
 
 /**
  * The frozen objects must match the 
  *  enumerations in storage.h under /main/,
+ *  enumerations in utils.h under /main/,
  *  HTTP status codes in webInterface.cpp under /main/
  *  enumerations in Wave.h /src/ in the AudioLab respository
  */
@@ -33,6 +35,34 @@ export const MODULE_TYPE = Object.freeze({
   0: "Major Peaks",
   1: "Percussion"
 });
+export const QUEUE_MESSAGE_ID = Object.freeze({
+  EditGlobal: 0,
+  EditModule: 1
+});
+export const CONFIG_FIELDS = Object.freeze({
+  // Global
+  "noiseFloor": 0,
+  "cfarRefCount": 1,
+  "cfarGuardCount": 2,
+  "cfarBias": 3,
+  "smoothingFactor": 4,
+  "minAmpNorm": 5,
+
+  // Shared module fields
+  "freqLow": 6,
+  "freqHigh": 7,
+  "outputNumber": 8,
+
+  // MajorPeaks
+  "maxPeaks": 9,
+  "frequencyMapping": 10,
+
+  // Percussion
+  "fluxThresh": 11,
+  "energyThresh": 12,
+  "entropyThresh": 13,
+  "waveType": 14
+});
 export const WAVE_TYPE = Object.freeze({
   0: "Sine",
   1: "Cosine",
@@ -40,7 +70,6 @@ export const WAVE_TYPE = Object.freeze({
   3: "Sawtooth",
   4: "Triangle"
 });
-
 
 // Internal
 export const PAGE = {
@@ -70,6 +99,9 @@ export const api = async (method, endpoint, data = null) => {
       case "POST": {
         return (await axios.post(url, data));
       }
+      case "PATCH": {
+        return (await axios.patch(url, data));
+      }
       case "PUT": {
         return (await axios.put(url, data));
       }
@@ -80,8 +112,57 @@ export const api = async (method, endpoint, data = null) => {
         throw new Error(`Unknown HTTP method: ${method}`);
       }
     }
-  } catch (error) {
+  }
+  catch (error) {
     console.error(`API Error [${method} ${url}]:`, error.message);
     return null;
   }
 };
+
+/**
+ * @brief Hook for editing settings in real-time. Calls the API form the web server
+ *        a max of 1/500ms when the setting is being changed to prevent flooding the web server
+ * 
+ * @param {Number} type - Message id to pass to the web server (type QUEUE_MESSAGE_ID)
+ * @param {Object} isValid - Optional mutable reference to an isValid boolean 
+ * 
+ * @returns Hook for the edit setting callback
+ */
+export function useEditSetting(type, isValid = null) {
+  const timers = useRef({});
+
+  // This will be called every update
+  const editSetting = useCallback( (setting) => {
+    clearTimeout(timers.current[setting.id]);
+
+    if (isValid?.current === false) return;
+
+    // Only called after 500ms after setting is settled
+    timers.current[setting.id] = setTimeout( async () => {
+      try {
+        const payload = {
+          ...setting,
+          type: type
+        };
+        const res = await api("PATCH", "/analysis/editSetting", payload);
+
+        if (res.status == HTTP_STATUS.OK) {
+          console.log("yuhhhh");
+        }
+      } 
+      catch (error) {
+        console.log(error);
+      }
+    }, 500);
+
+  }, [type]);
+
+  // Clean up the timers when in-use UI component is unmounted
+  useEffect( () => {
+    return () => {
+      Object.values(timers.current).forEach(clearTimeout);
+    }
+  }, []);
+
+  return { editSetting };
+}

--- a/main/hapticSettings.cpp
+++ b/main/hapticSettings.cpp
@@ -20,21 +20,93 @@
 
 #define MAIN_ANALYSIS_PATH "/data/mainConfig.json"
 
+// Queue stuff
+#define QUEUE_LENGTH 12
+#define ITEM_SIZE sizeof(QueueMessage)
+
+static QueueHandle_t updateQueue;
+static StaticQueue_t staticQueue;
+uint8_t ucQueueStorageArea[ QUEUE_LENGTH * ITEM_SIZE ];
+
+/**
+ * @brief Plain constructor
+ * 
+ */
 HapticSettings::HapticSettings() :
-  curConfig{ nullptr },
-  _isDirty{ false }
+  curConfig{ nullptr }
 {}
+
+/**
+ * @brief Loads an analysis config and inits the update queue
+ * 
+ * @return Boolean indicating if the settings are initialized properly 
+ */
+bool HapticSettings::init()
+{
+  loadConfig();
+
+  updateQueue = xQueueCreateStatic(
+    QUEUE_LENGTH,
+    ITEM_SIZE,
+    ucQueueStorageArea,
+    &staticQueue
+  );
+
+  return (updateQueue != NULL);
+}
+
+/**
+ * @brief Adds a message to the update queue
+ * 
+ * @param toSend - Pointer to the message to add
+ * 
+ * @return Bool indicating if the message could be added
+ */
+bool HapticSettings::addMessage(QueueMessage* toSend)
+{
+  return (xQueueSend(
+    updateQueue,
+    toSend,
+    0
+  ) == pdPASS);
+}
+
+/**
+ * @brief Pops a message from the update queue
+ * 
+ * @param toGet - POinter to the message to be populated
+ *
+ * @return Bool indicating if a message could be popped 
+ */
+bool HapticSettings::getMessage(QueueMessage* toGet)
+{
+  return (xQueueReceive(
+    updateQueue,
+    toGet,
+    0
+  ) == pdPASS);
+}
+
+/**
+ * @brief Checks if the queue has messages
+ * 
+ * @return Bool indicating if the queue has messages
+ */
+bool HapticSettings::needsUpdate()
+{
+  return (uxQueueMessagesWaiting(updateQueue) != 0);
+}
 
 /**
  * @brief Populates the analysis configurations using the data found in the
  *        SD card, falling back onto an internal preset of the data file is not
  *        found.
- * 
+ *
  * @return Bool indicating if the loaded configuration was found from SD card.
  *         True if found on SD card.
  *         False if using preset.
  */
-bool HapticSettings::loadConfig()
+void HapticSettings::loadConfig()
 {
   JsonDocument doc;
   bool usingSavedConfig {false};
@@ -81,7 +153,36 @@ bool HapticSettings::loadConfig()
     this->curConfig->modules[3] =
       std::make_unique<MajorPeaksConfig>(0, 400, 1000, OCTAVE, 1);
   }
-  this->setIsDirty(true);
+}
 
-  return usingSavedConfig;
+/**
+ * @brief Processes each message in the update queue
+ * 
+ * NOTE: This should be thread-safe since adding messages requires the instance, so it'll wait until
+ *       this is done processing before adding. 
+ * 
+ * @return Bool indicating if the modules need to be rebuilt
+ */
+bool HapticSettings::processQueue()
+{
+  QueueMessage msg;
+  bool needsRebuild = false;
+
+  while (HapticSettings::Instance().getMessage(&msg))
+  {
+    switch (msg.id)
+    {
+      case QueueMsgId::EditGlobal:
+        Utils::applyGlobalEdit(curConfig.get(), msg);
+        break;
+
+      case QueueMsgId::EditModule:
+        needsRebuild |= Utils::applyModuleEdit(curConfig.get(), msg);
+        break;
+
+      default:
+        break;
+    }
+  }
+  return needsRebuild;
 }

--- a/main/hapticSettings.cpp
+++ b/main/hapticSettings.cpp
@@ -180,6 +180,9 @@ bool HapticSettings::processQueue()
         needsRebuild |= Utils::applyModuleEdit(curConfig.get(), msg);
         break;
 
+      case QueueMsgId::UpdateAll:
+        needsRebuild = true;
+
       default:
         break;
     }

--- a/main/hapticSettings.h
+++ b/main/hapticSettings.h
@@ -13,6 +13,7 @@
 #define HAPTIC_SETTINGS_H
 
 #include "storage.h"
+#include "utils.h"
 #include <memory>
 #include <atomic>
 
@@ -26,9 +27,9 @@ public:
     static HapticSettings self;
     return self;
   };
-  //! Sets the current config to the saved main settings on the SD card
-  bool loadConfig();
-  
+  //! Loads a config and inits the message queue
+  bool init();
+
   //! Atomically gets the current config
   //! NOTE: this should only be called by audio analysis loop b/c it's read only
   std::shared_ptr<const AnalysisConfig> getConfig_r() const { return std::atomic_load(&curConfig); }
@@ -36,19 +37,27 @@ public:
   //! Atomically get a mutable pointer to the current config
   auto getConfig_mut() const { return std::atomic_load(&curConfig); }
 
+  //! Adds a message to the update queue for the audio core to use
+  bool addMessage(QueueMessage* toSend);
+  
+  //! Checks if the update queue has pending messages
+  bool needsUpdate();
+
   //! Atomically swaps the current config with the new config
   void updateConfig(std::shared_ptr<AnalysisConfig>& other) { std::atomic_store(&curConfig, other); }
 
-  //! Atomically get whether or not settings have been changed
-  bool isDirty() const { return _isDirty.load(std::memory_order_acquire); }
-
-  //! Atomically set the dirty boolean.
-  void setIsDirty(const bool NewVal) { _isDirty.store(NewVal, std::memory_order_release); }
+  //! Processes all messages in the update queue
+  bool processQueue();
 
 private:
-  // Use shared ptr, so that we can update the settings fast/safe across cores
+  // Use shared ptr, so that we can replace the settings fast/safe across cores
   std::shared_ptr<AnalysisConfig> curConfig;
-  std::atomic<bool> _isDirty;
+
+  //! Sets the current config to the saved main settings on the SD card
+  void loadConfig();
+
+  //! Gets a message from the update queue
+  bool getMessage(QueueMessage* toGet);
 
   // Disable any sort of initialization for the HapticSettings class
   HapticSettings();

--- a/main/main.ino
+++ b/main/main.ino
@@ -22,6 +22,7 @@
 
 // Vibrosonics audio analysis globals
 VibrosonicsAPI vapi = VibrosonicsAPI();
+std::shared_ptr<AnalysisConfig> activeConfig {nullptr};
 
 float windowData[WINDOW_SIZE_BY_2] = { 0 };
 float filteredData[WINDOW_SIZE_BY_2] = { 0 };
@@ -91,6 +92,8 @@ void setup()
   (void) WebInterface::init();
 #endif
 
+  success &= HapticSettings::Instance().init();
+
   const auto CreatedTask = xTaskCreatePinnedToCore(
     webRunner,
     "webServer",
@@ -116,10 +119,11 @@ void setup()
   #ifdef VAPI_EN
     DEBUG_PRINTLN("DEBUG: Initializing VAPI");
 
-    // TODO: maybe change this to init() that calls loadConfig()
-    (void) HapticSettings::Instance().loadConfig();
-    vapi.init();
+    activeConfig = HapticSettings::Instance().getConfig_mut();
+    rebuildOutputModules(activeConfig.get());
     durEnv = vapi.createDurEnv(1, 0, 1, 3, 1.0);
+
+    vapi.init();
   #endif
 }
 
@@ -133,14 +137,14 @@ void loop()
   if (!vapi.isAudioLabReady())
     return;
 
-  auto activeConfig = HapticSettings::Instance().getConfig_r();
-
-  if (HapticSettings::Instance().isDirty())
+  if (HapticSettings::Instance().needsUpdate())
   {
-    rebuildOutputModules(activeConfig.get());
-    HapticSettings::Instance().setIsDirty(false);
+    DEBUG_PRINTLN("DEBUG: processing queue...");
+
+    // NOTE: only returns true when it actually needs to be rebuilt, not every time it processes a request
+    if (HapticSettings::Instance().processQueue())
+      rebuildOutputModules(activeConfig.get());
   }
-  
   processData(activeConfig);
 
   melodic.runAnalysis();
@@ -197,7 +201,7 @@ void performModuleAnalysis(AnalysisModule* module, const ModuleConfig* moduleCon
         const PercussionConfig* percussionConfig = static_cast<const PercussionConfig*>(moduleConfig);
         // If percussion was detected, synthesize a hit
         if (percModuleInterface->getOutput()) {
-          DEBUG_PRINTLN("Percussion hit detected");
+          // DEBUG_PRINTLN("Percussion hit detected");
           // Get the energy, entropy and positive flux for the percussive hit. These
           // values are used to synthesize the haptic feedback of the percussion.
           float energy = AudioPrism::energy(percussiveData, 

--- a/main/main.ino
+++ b/main/main.ino
@@ -143,7 +143,11 @@ void loop()
 
     // NOTE: only returns true when it actually needs to be rebuilt, not every time it processes a request
     if (HapticSettings::Instance().processQueue())
+    {
+      // Get the most recent config incase some were deleted or added
+      activeConfig = HapticSettings::Instance().getConfig_mut();
       rebuildOutputModules(activeConfig.get());
+    }
   }
   processData(activeConfig);
 
@@ -201,7 +205,7 @@ void performModuleAnalysis(AnalysisModule* module, const ModuleConfig* moduleCon
         const PercussionConfig* percussionConfig = static_cast<const PercussionConfig*>(moduleConfig);
         // If percussion was detected, synthesize a hit
         if (percModuleInterface->getOutput()) {
-          // DEBUG_PRINTLN("Percussion hit detected");
+          DEBUG_PRINTLN("Percussion hit detected");
           // Get the energy, entropy and positive flux for the percussive hit. These
           // values are used to synthesize the haptic feedback of the percussion.
           float energy = AudioPrism::energy(percussiveData, 
@@ -260,12 +264,16 @@ void performModuleAnalysis(AnalysisModule* module, const ModuleConfig* moduleCon
         ModuleInterface<float**>* mpModuleInterface = static_cast<ModuleInterface<float**>*>(module);
         const MajorPeaksConfig* majorPeaksConfig = static_cast<const MajorPeaksConfig*>(moduleConfig);
         float **analysisData = mpModuleInterface->getOutput();
-        synthesizePeak(moduleConfig->outputNumber, 
-                        analysisData[MP_FREQ][0], 
-                        analysisData[MP_AMP][0], 
-                        moduleConfig->freqLow, 
-                        moduleConfig->freqHigh, 
-                        majorPeaksConfig->frequencyMapping);
+
+        for (auto i {0}; i < majorPeaksConfig->maxPeaks; i++)
+        {
+          synthesizePeak(moduleConfig->outputNumber, 
+                          analysisData[MP_FREQ][i], 
+                          analysisData[MP_AMP][i], 
+                          moduleConfig->freqLow, 
+                          moduleConfig->freqHigh, 
+                          majorPeaksConfig->frequencyMapping);
+        }
         break;
       }
     default:

--- a/main/storage.h
+++ b/main/storage.h
@@ -15,6 +15,36 @@
 #include <AudioLab.h>
 #include <memory>
 
+// Enums for the config fields for real-time updates
+enum class ConfigField : uint
+{
+  // Global
+  NoiseFloor = 0u,
+  CfarRefCount,
+  CfarGuardCount,
+  CfarBias,
+  SmoothingFactor,
+  MinAmpNorm,
+
+  // Marker for global fields
+  GLOBAL_END = MinAmpNorm,
+
+  // Shared module fields
+  FreqLow,
+  FreqHigh,
+  OutputNumber,
+
+  // MajorPeaks
+  MaxPeaks,
+  FrequencyMapping,
+
+  // Percussion
+  FluxThresh,
+  EnergyThresh,
+  EntropyThresh,
+  WaveType
+};
+
 enum FrequencyMapping{
   NONE = 0,
   OCTAVE,

--- a/main/utils.cpp
+++ b/main/utils.cpp
@@ -124,10 +124,11 @@ void Utils::packageModulesList(JsonArray& modulesList, AnalysisConfig* config)
   // Allocate memory in the array
   JsonObject module = modulesList.add<JsonObject>();
 
-  module["outputNumber"] = static_cast<int>(config->modules[i]->outputNumber);
-  module["moduleType"] = static_cast<int>(config->modules[i]->moduleType);
-  module["freqLow"] = static_cast<int>(config->modules[i]->freqLow);
-  module["freqHigh"] = static_cast<int>(config->modules[i]->freqHigh);
+  module["index"] = i;
+  module["outputNumber"] = config->modules[i]->outputNumber;
+  module["moduleType"] = config->modules[i]->moduleType;
+  module["freqLow"] = config->modules[i]->freqLow;
+  module["freqHigh"] = config->modules[i]->freqHigh;
 
   // Do the rest params under a function that takes in the type or use branching, for now just do this for MajorPeaks
   if (config->modules[i]->moduleType == MAJORPEAKS)
@@ -152,6 +153,7 @@ void Utils::packageModulesList(JsonArray& modulesList, AnalysisConfig* config)
  *        the factory method w/ a map.
  * 
  * @param Type - Type of module config to create.
+ *
  * @return ModulePtr - Unique pointer of the passed in module type.
  */
 inline ModulePtr Utils::createModule(const ModuleType Type)
@@ -167,4 +169,199 @@ inline ModulePtr Utils::createModule(const ModuleType Type)
   // Ex: ( ModuleType, unique_ptr for module )
   auto itr = Map.find(Type);
   return (itr == Map.end() ? nullptr : itr->second());
+}
+
+/**
+ * @brief Creates a message from the JsonObject data
+ * 
+ * @param id - Message id to use
+ * @param payload - Reference to the data source
+ * @param msg - Message structure to be populated
+ */
+void Utils::createMessage(const QueueMsgId id, const JsonObject& payload, QueueMessage& msg)
+{
+  msg.id = id;
+  msg.field = static_cast<ConfigField>(payload["field"].as<uint>());
+
+  switch (id)
+  {
+    case QueueMsgId::EditGlobal:
+    {
+      switch (msg.field)
+      {
+        case ConfigField::CfarRefCount:
+        case ConfigField::CfarGuardCount:
+          msg.global.value.u16 = payload["value"].as<uint16_t>();
+          break;
+
+        case ConfigField::NoiseFloor:
+        case ConfigField::CfarBias:
+        case ConfigField::SmoothingFactor:
+        case ConfigField::MinAmpNorm:
+          msg.global.value.f = payload["value"].as<float>();
+          break;
+
+        default:
+          break;
+      }
+      break;
+    }
+    case QueueMsgId::EditModule:
+    {
+      msg.module.index = payload["index"].as<int>();
+
+      switch (msg.field)
+      {
+        case ConfigField::FreqLow:
+        case ConfigField::FreqHigh:
+          msg.module.value.u16 = payload["value"].as<uint16_t>();
+          break;
+
+        case ConfigField::OutputNumber:
+        case ConfigField::MaxPeaks:
+          msg.module.value.i = payload["value"].as<int>();
+          break;
+
+        case ConfigField::FrequencyMapping:
+          msg.module.value.fm = payload["value"].as<FrequencyMapping>();
+          break;
+
+        case ConfigField::WaveType:
+          msg.module.value.wt = payload["value"].as<WaveType>();
+          break;
+
+        case ConfigField::FluxThresh:
+        case ConfigField::EnergyThresh:
+        case ConfigField::EntropyThresh:
+          msg.module.value.f = payload["value"].as<float>();
+          break;
+
+        default:
+          break;
+      }
+    }
+    default:
+      break;
+  }
+}
+
+/**
+ * @brief Updates the global config field using the message
+ * 
+ * @param config - Config pointer to be edited
+ * @param msg - Message holding which field and what value to use
+ */
+void Utils::applyGlobalEdit(AnalysisConfig* config, const QueueMessage& msg)
+{
+  switch (msg.field)
+  {
+    case ConfigField::NoiseFloor: 
+      config->noiseFloor = msg.global.value.f;
+      break;
+
+    case ConfigField::CfarRefCount:
+      config->cfarRefCount = msg.global.value.u16;
+      break;
+
+    case ConfigField::CfarGuardCount:  
+      config->cfarGuardCount  = msg.global.value.u16;
+      break;
+
+    case ConfigField::CfarBias:        
+      config->cfarBias = msg.global.value.f;
+      break;
+
+    case ConfigField::SmoothingFactor: 
+      config->smoothingFactor = msg.global.value.f;
+      break;
+
+    case ConfigField::MinAmpNorm:      
+      config->minAmpNorm = msg.global.value.f;
+      break;
+
+    default:
+      break;
+  }
+}
+
+/**
+ * @brief Updates the module config within the analysis config
+ * 
+ * @param config - Config pointer to edit
+ * @param msg - Message holding which index, field, and what value to use
+ *
+ * @return Bool indicating if the modules need to be rebuilt in the main loop 
+ */
+bool Utils::applyModuleEdit(AnalysisConfig* config, const QueueMessage& msg)
+{
+  if (!config->modules[msg.module.index])
+    return false;
+    
+  ModuleConfig* mod = config->modules[msg.module.index].get();
+
+  switch (msg.field)
+  {
+    case ConfigField::FreqLow:      
+      mod->freqLow = msg.module.value.u16; 
+      return true;
+
+    case ConfigField::FreqHigh:     
+      mod->freqHigh = msg.module.value.u16; 
+      return true;
+      
+    case ConfigField::OutputNumber: 
+      mod->outputNumber = msg.module.value.i; 
+      return true;
+
+    default:
+      break;
+  }
+
+  switch (mod->moduleType)
+  {
+    case MAJORPEAKS:
+    {
+      auto* mp = static_cast<MajorPeaksConfig*>(mod);
+      switch (msg.field)
+      {
+        case ConfigField::MaxPeaks:         
+          mp->maxPeaks = msg.module.value.i; 
+          return false;
+
+        case ConfigField::FrequencyMapping: 
+          mp->frequencyMapping = msg.module.value.fm; 
+          return false;
+
+        default:
+          return false;
+      }
+    }
+    case PERCUSSION:
+    {
+      auto* pc = static_cast<PercussionConfig*>(mod);
+      switch (msg.field)
+      {
+        case ConfigField::FluxThresh:   
+          pc->fluxThresh = msg.module.value.f;
+          return true;
+
+        case ConfigField::EnergyThresh: 
+          pc->energyThresh = msg.module.value.f;
+          return true;
+
+        case ConfigField::EntropyThresh:
+          pc->entropyThresh = msg.module.value.f;
+          return true;
+
+        case ConfigField::WaveType:     
+          pc->waveType = msg.module.value.wt;
+          return false;
+
+        default:
+          return false;
+      }
+    }
+    default:
+      return false;
+  }
 }

--- a/main/utils.cpp
+++ b/main/utils.cpp
@@ -240,6 +240,7 @@ void Utils::createMessage(const QueueMsgId id, const JsonObject& payload, QueueM
           break;
       }
     }
+    case QueueMsgId::UpdateAll:   // Just needs the ID for a rebuild
     default:
       break;
   }

--- a/main/utils.h
+++ b/main/utils.h
@@ -15,6 +15,48 @@
 #include "storage.h"
 #include <Arduino.h>
 #include <ArduinoJson.h>
+#include <cstdint>
+
+// Structures for messaging based communication between cores
+enum class QueueMsgId : uint
+{
+  EditGlobal = 0u,
+  EditModule
+  // Create/delete module?
+};
+
+struct EditGlobalData
+{
+  union {
+    int i;
+    uint16_t u16;
+    float f;
+  } value;
+};
+
+struct EditModuleData
+{
+  int index;
+
+  union {
+    int i;
+    uint16_t u16;
+    float f;
+    FrequencyMapping fm;
+    WaveType wt;
+  } value;
+};
+
+struct QueueMessage
+{
+  QueueMsgId id;
+  ConfigField field;
+
+  union {
+    EditGlobalData global;
+    EditModuleData module;
+  };
+};
 
 namespace Utils
 {
@@ -36,6 +78,15 @@ namespace Utils
 
   //! Creates an instance of ModulePtr based on the module type
   inline ModulePtr createModule(const ModuleType Type);
+
+  //! Creates a message for the update queue
+  void createMessage(const QueueMsgId id, const JsonObject& payload, QueueMessage& msg);
+
+  //! Edits the global config data using the message as which field and value
+  void applyGlobalEdit(AnalysisConfig* config, const QueueMessage& msg);
+
+  //! Edits the module config data using the message as which field, index, and value
+  bool applyModuleEdit(AnalysisConfig* config, const QueueMessage& msg);
 }
 
 #endif

--- a/main/utils.h
+++ b/main/utils.h
@@ -21,7 +21,8 @@
 enum class QueueMsgId : uint
 {
   EditGlobal = 0u,
-  EditModule
+  EditModule,
+  UpdateAll
   // Create/delete module?
 };
 

--- a/main/webInterface.cpp
+++ b/main/webInterface.cpp
@@ -127,8 +127,6 @@ inline void WebInterface::setupServer()
   // Haptic settings API
   server.on("/analysis/getSettings", HTTP_GET, sendAnalysisConfig);
   server.on("/analysis/submitSettings", HTTP_PUT, onSubmitConfig);
-
-  // Real-time updates
   server.on("/analysis/editSetting", HTTP_PATCH, onEditSetting);
 
   // Make /assets/ public for the server
@@ -277,20 +275,22 @@ void WebInterface::onSubmitConfig()
     // Creating a new AnalysisConfig for the audio loop and adding settings. Once loop() is done,
     // it calls HapticSettings::Instance().getConfig_r() again, which then deletes the old config
     // since there are no more owners of that pointer
-    // auto newConfig = std::make_shared<AnalysisConfig>();
-    // auto globalSettings = payload["global"].as<JsonObject>();
-    // auto modulesList = payload["modules"].as<JsonArray>();
+    auto newConfig = std::make_shared<AnalysisConfig>();
+    auto globalSettings = payload["global"].as<JsonObject>();
+    auto modulesList = payload["modules"].as<JsonArray>();
 
-    // Utils::populateGlobalSettings(globalSettings, newConfig.get());
-    // Utils::populateModulesList(modulesList, newConfig.get());
+    Utils::populateGlobalSettings(globalSettings, newConfig.get());
+    Utils::populateModulesList(modulesList, newConfig.get());
 
-    hasUpdated = true;
-    // HapticSettings::Instance().updateConfig(newConfig);
+    HapticSettings::Instance().updateConfig(newConfig);
 
-    // // FIXME: technically only has to get set in specific situations that would require the 
-    // //        modules to get reconstructed (like a module changing from major peaks to percussion,
-    // //        the flux threshold changing, etc.). If we notice that rebuilding the modules every time 
-    // //        is causing lag or other issues, we should add logic to handle it more gracefully
+    // Just needs the ID for a pointer swap, no need for a createMessage call
+    QueueMessage msg {
+      .id = QueueMsgId::UpdateAll
+    };
+
+    if (HapticSettings::Instance().addMessage(&msg))
+      hasUpdated = true;
   }
   if (hasUpdated)
     resStatus = HTTP_OK;

--- a/main/webInterface.cpp
+++ b/main/webInterface.cpp
@@ -27,6 +27,7 @@ constexpr int HTTP_ACCEPTED = 202;
 constexpr int HTTP_BAD_REQUEST = 400;
 constexpr int HTTP_NOT_FOUND = 404;
 constexpr int HTTP_UNPROCESSABLE = 422;
+constexpr int HTTP_TOO_MANY_REQUESTS = 429;
 constexpr int HTTP_INTERNAL_ERROR = 500;
 constexpr int HTTP_UNAVAILABLE = 503;
 
@@ -51,6 +52,7 @@ File _uploadFile;
 // Internal web server functions
 static String getContentType(const String &Path);
 static bool parsePayload(JsonDocument &output);
+inline void limitReqRate(const unsigned long Time_ms);
 
 /**
  * @brief Function that bypasses CORS restrictions when DEV_MODE_EN is enabled.
@@ -126,6 +128,9 @@ inline void WebInterface::setupServer()
   server.on("/analysis/getSettings", HTTP_GET, sendAnalysisConfig);
   server.on("/analysis/submitSettings", HTTP_PUT, onSubmitConfig);
 
+  // Real-time updates
+  server.on("/analysis/editSetting", HTTP_PATCH, onEditSetting);
+
   // Make /assets/ public for the server
   server.serveStatic("/", SD, "/assets/");
   server.onNotFound(onNotFoundHandler);
@@ -159,7 +164,7 @@ void WebInterface::onNotFoundHandler()
   // Needed to bypass some CORS requests
   if (server.method() == HTTP_OPTIONS)
   {
-    send(HTTP_OK);
+    send(HTTP_ACCEPTED);
     
     return;
   }
@@ -256,6 +261,8 @@ void WebInterface::sendAnalysisConfig()
  * @brief Parses the submitted analysis configuration, updates the config
  *        in HapticSettings, and sends the response status.
  * 
+ * TODO: this could prolly change to save config
+ * 
  */
 void WebInterface::onSubmitConfig()
 {
@@ -270,21 +277,46 @@ void WebInterface::onSubmitConfig()
     // Creating a new AnalysisConfig for the audio loop and adding settings. Once loop() is done,
     // it calls HapticSettings::Instance().getConfig_r() again, which then deletes the old config
     // since there are no more owners of that pointer
-    auto newConfig = std::make_shared<AnalysisConfig>();
-    auto globalSettings = payload["global"].as<JsonObject>();
-    auto modulesList = payload["modules"].as<JsonArray>();
+    // auto newConfig = std::make_shared<AnalysisConfig>();
+    // auto globalSettings = payload["global"].as<JsonObject>();
+    // auto modulesList = payload["modules"].as<JsonArray>();
 
-    Utils::populateGlobalSettings(globalSettings, newConfig.get());
-    Utils::populateModulesList(modulesList, newConfig.get());
+    // Utils::populateGlobalSettings(globalSettings, newConfig.get());
+    // Utils::populateModulesList(modulesList, newConfig.get());
 
     hasUpdated = true;
-    HapticSettings::Instance().updateConfig(newConfig);
+    // HapticSettings::Instance().updateConfig(newConfig);
 
-    // FIXME: technically only has to get set in specific situations that would require the 
-    //        modules to get reconstructed (like a module changing from major peaks to percussion,
-    //        the flux threshold changing, etc.). If we notice that rebuilding the modules every time 
-    //        is causing lag or other issues, we should add logic to handle it more gracefully
-    HapticSettings::Instance().setIsDirty(true);
+    // // FIXME: technically only has to get set in specific situations that would require the 
+    // //        modules to get reconstructed (like a module changing from major peaks to percussion,
+    // //        the flux threshold changing, etc.). If we notice that rebuilding the modules every time 
+    // //        is causing lag or other issues, we should add logic to handle it more gracefully
+  }
+  if (hasUpdated)
+    resStatus = HTTP_OK;
+
+  send(resStatus);
+}
+
+// TODO: add header comment
+void WebInterface::onEditSetting()
+{
+  limitReqRate(500u);
+
+  JsonDocument payload;
+  int resStatus = HTTP_UNPROCESSABLE;
+  bool hasUpdated = false;
+
+  if (parsePayload(payload))
+  {
+    QueueMessage msg {};
+    auto data = payload.as<JsonObject>();
+    auto type = static_cast<QueueMsgId>(payload["type"].as<uint>());
+
+    Utils::createMessage(type, data, msg);
+
+    if (HapticSettings::Instance().addMessage(&msg))
+      hasUpdated = true;
   }
   if (hasUpdated)
     resStatus = HTTP_OK;
@@ -336,6 +368,20 @@ static bool parsePayload(JsonDocument &output)
     return false;
   }
   return true;
+}
+
+// TODO: add comment
+inline void limitReqRate(const unsigned long Time_ms)
+{
+  static unsigned long lastReq_ms = 0;
+  auto now = millis();
+
+  if (now - lastReq_ms < Time_ms)
+  {
+    send(HTTP_TOO_MANY_REQUESTS);
+    return;
+  }
+  lastReq_ms = now;
 }
 
 #ifdef DEV_MODE_EN

--- a/main/webInterface.h
+++ b/main/webInterface.h
@@ -43,6 +43,9 @@ namespace WebInterface
   //! Handler for updating the HapticSettings config
   void onSubmitConfig();
 
+  //! Handler for real-time updates
+  void onEditSetting();
+
   #ifdef DEV_MODE_EN
     //! Initializes the web server assuming the web app in upload files mode 
     inline void setupUploadMode();


### PR DESCRIPTION
This PR contains a rework of the previous methods of analysis config settings modifications for real-time updates along with integration of the static percussion fix and add/delete modules feature.

Previous Method:
The original design of updating configurations would sent the entire configuration over HTTP to core 0, parse the JSON data into a shared pointer, then insert the shared pointer into the HapticSettings class, so that the core 1 loop would grab the new config if the dirty flag was sent, delete the old shared pointer, then rebuild the modules for the ModuleGroup class (all happening within a UI button press). Adding and deleting modules still use this method, for integration sake.

New Method:
FreeRTOS gives us access to queues for cross core communication, which allows us to send small data packets between each core safely. The individual settings are now tied to an ID and the updated value, packaged together into a message, then placed into the queue for core 1 to consume and update itself. A bunch of switch statements and branching is needed for this to work, so adding new fields and modules would require adding on top of them, but everything works as intended.