### PR TITLE
fix: fix index and outputNumber inconsistencies

### DIFF
--- a/WebApp/src/components/analysisModule.jsx
+++ b/WebApp/src/components/analysisModule.jsx
@@ -19,7 +19,7 @@ import { moduleRegistry } from "../data/defaultModules";
  * @brief The AnalysisModule component describe a full module that can be modified
  * 
  * @param {Object} _ - Object describing the configurations
- * @param {Number} _.outputNum - Index of module to be updated using the modules context
+ * @param {Number} _.outputNum - Output number of module to be updated using the modules context
  * @param {Object} _.module - Module configuration to modify
  * @param {CallableFunction} _.setModules - Callback for actually updating the module settings and UI
  * 
@@ -84,8 +84,7 @@ export default function AnalysisModule({ outputNum, module, setModules }) {
 
     // Send the updated val to the web server
     editSetting({
-      // This index is for the position in the web server array
-      index: module.index,
+      outputNumber: outputNum,
       field: CONFIG_FIELDS[id],
       value: val
     })
@@ -98,7 +97,7 @@ export default function AnalysisModule({ outputNum, module, setModules }) {
     if (!window.confirm("Are you sure you want to delete this module?")) {
       return;
     }
-    const query = `index=${module.index}`;
+    const query = `outputNumber=${module.outputNumber}`;
     const res = await api("DELETE", `/analysis/deleteModule?${query}`);
 
     if (res?.status == HTTP_STATUS.OK) {
@@ -116,7 +115,7 @@ export default function AnalysisModule({ outputNum, module, setModules }) {
     if (newType === -1) return;
 
     // delete current module
-    const query = `index=${module.index}`;
+    const query = `outputNumber=${module.outputNumber}`;
 
     const deleteRes = await api("DELETE", `/analysis/deleteModule?${query}`);
     if (deleteRes?.status !== HTTP_STATUS.OK) return;
@@ -145,27 +144,7 @@ export default function AnalysisModule({ outputNum, module, setModules }) {
    * @brief Mutes or unmutes current output
    */
   const handleMutePressed = () => {
-    const updatedMuteVal = !module.isMuted;
-
-    // Update the UI
-    setModules((prev) =>
-      prev.map((m) => {
-        if (m.outputNumber !== outputNum) return m;
-
-        return {
-          ...m,
-          isMuted: updatedMuteVal,
-        };
-      })
-    );
-
-    // Send the updated val to the web server
-    editSetting({
-      // This index is for the position in the web server array
-      index: module.index,
-      field: CONFIG_FIELDS["isMuted"],
-      value: updatedMuteVal
-    })
+    handleValueChange("isMuted", !module.isMuted);
   }
 
   return (

--- a/WebApp/src/data/moduleDisplay.json
+++ b/WebApp/src/data/moduleDisplay.json
@@ -22,8 +22,8 @@
         "minAmpNorm": {
           "title": "Min Amplitude Norm",
           "min": 1,
-          "max": 20000000,
-          "step": 0.01,
+          "max": 40000,
+          "step": 100.0,
           "description": "This establishes the absolute minimum intensity threshold a signal must reach to be registered by the system. Any signal falling below this magnitude is discarded as background noise, which helps prevent false positive detections."
         }
       },
@@ -63,7 +63,7 @@
           "title": "Min Amplitude Norm",
           "min": 1,
           "max": 20000000,
-          "step": 0.01
+          "step": 1000.0
         },
         "fluxThresh": {
           "title": "Flux Threshold",

--- a/WebApp/src/pages/modulesPage.jsx
+++ b/WebApp/src/pages/modulesPage.jsx
@@ -58,34 +58,31 @@ const ModulesPage = () => {
   return (
     <div className="flex flex-col m-8">
       <ConfigManager>
-        {/* TODO: better way to check if module load failed? */}
-        {modules.length != 0 && (
-          <div className="flex flex-row gap-4">
-            {/* Either display empty slot or module assigned to each output
-                We pass in module because the actual modules being sent to the server
-                are updated here, rather than creating a copy of the module
-            */}
-            {outputs.map((module, outputNum) => {
-              return (
-                <div key={outputNum} className="gap-3 flex flex-col items-center">
-                  <p>Output {outputNum + 1}</p>
-                  {module === null ? (
-                    <EmptyOutput
-                      outputNum={outputNum}
-                      setModules={setModules}
-                    />
-                  ) : (
-                    <AnalysisModule
-                      outputNum={outputNum}
-                      module={module}
-                      setModules={setModules}
-                    />
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        )}
+        <div className="flex flex-row gap-4">
+          {/* Either display empty slot or module assigned to each output
+              We pass in module because the actual modules being sent to the server
+              are updated here, rather than creating a copy of the module
+          */}
+          {outputs.map((module, outputNum) => {
+            return (
+              <div key={outputNum} className="gap-3 flex flex-col items-center">
+                <p>Output {outputNum + 1}</p>
+                {module === null ? (
+                  <EmptyOutput
+                    outputNum={outputNum}
+                    setModules={setModules}
+                  />
+                ) : (
+                  <AnalysisModule
+                    outputNum={outputNum}
+                    module={module}
+                    setModules={setModules}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
         <GlobalSettings
           globalSettings={globalSettings}
           setGlobalSettings={setGlobalSettings}

--- a/main/hapticSettings.cpp
+++ b/main/hapticSettings.cpp
@@ -180,27 +180,27 @@ bool HapticSettings::processQueue()
 
       case QueueMsgId::CreateModule:
       {
-        const int Index = msg.module.index;
+        const int outputNumber = msg.module.outputNumber;
         
-        if (Index >= 0 && Index < NUM_OUT_CH)
+        if (outputNumber >= 0 && outputNumber < NUM_OUT_CH)
         {
           const auto Type = static_cast<ModuleType>(msg.module.value.i);
           auto newModule = Utils::createModule(Type);
 
           if (!newModule) break;
 
-          newModule->outputNumber = Index;
-          curConfig->modules[Index] = std::move(newModule);
+          newModule->outputNumber = outputNumber;
+          curConfig->modules[outputNumber] = std::move(newModule);
           needsRebuild = true;
         }
         break;
       }
       case QueueMsgId::DeleteModule:
       {
-        const int Index = msg.module.index;
+        const int outputNumber = msg.module.outputNumber;
         
-        if (Index >= 0 && Index < NUM_OUT_CH) {
-          curConfig->modules[Index] = nullptr;
+        if (outputNumber >= 0 && outputNumber < NUM_OUT_CH) {
+          curConfig->modules[outputNumber] = nullptr;
           needsRebuild = true;
         }
         break;

--- a/main/utils.cpp
+++ b/main/utils.cpp
@@ -124,7 +124,6 @@ void Utils::packageModulesList(JsonArray& modulesList, AnalysisConfig* config)
   // Allocate memory in the array
   JsonObject module = modulesList.add<JsonObject>();
 
-  module["index"] = i;
   module["outputNumber"] = config->modules[i]->outputNumber;
   module["moduleType"] = config->modules[i]->moduleType;
   module["freqLow"] = config->modules[i]->freqLow;
@@ -208,7 +207,7 @@ void Utils::createMessage(const QueueMsgId id, const JsonObject& payload, QueueM
     }
     case QueueMsgId::EditModule:
     {
-      msg.module.index = payload["index"].as<int>();
+      msg.module.outputNumber = payload["outputNumber"].as<int>();
 
       switch (msg.field)
       {
@@ -290,16 +289,16 @@ void Utils::applyGlobalEdit(AnalysisConfig* config, const QueueMessage& msg)
  * @brief Updates the module config within the analysis config
  * 
  * @param config - Config pointer to edit
- * @param msg - Message holding which index, field, and what value to use
+ * @param msg - Message holding which output, field, and what value to use
  *
  * @return Bool indicating if the modules need to be rebuilt in the main loop 
  */
 bool Utils::applyModuleEdit(AnalysisConfig* config, const QueueMessage& msg)
 {
-  if (!config->modules[msg.module.index])
+  if (!config->modules[msg.module.outputNumber])
     return false;
     
-  ModuleConfig* mod = config->modules[msg.module.index].get();
+  ModuleConfig* mod = config->modules[msg.module.outputNumber].get();
 
   switch (msg.field)
   {

--- a/main/utils.h
+++ b/main/utils.h
@@ -38,7 +38,7 @@ struct EditGlobalData
 
 struct EditModuleData
 {
-  int index;
+  int outputNumber;
 
   union {
     int i;
@@ -88,7 +88,7 @@ namespace Utils
   //! Edits the global config data using the message as which field and value
   void applyGlobalEdit(AnalysisConfig* config, const QueueMessage& msg);
 
-  //! Edits the module config data using the message as which field, index, and value
+  //! Edits the module config data using the message as which field, output, and value
   bool applyModuleEdit(AnalysisConfig* config, const QueueMessage& msg);
 }
 

--- a/main/webInterface.cpp
+++ b/main/webInterface.cpp
@@ -330,19 +330,19 @@ void WebInterface::onEditSetting()
 }
 
 /**
- * @brief Adds a message to the haptic settings queue to delete a module at a given index in real-time.
+ * @brief Adds a message to the haptic settings queue to delete a module on a given output in real-time.
  * 
  */
 void WebInterface::onDeleteModule()
 {
-  if (!server.hasArg("index")) {
+  if (!server.hasArg("outputNumber")) {
     send(HTTP_UNPROCESSABLE);
     return;
   }
-  const int ModuleIndex = server.arg("index").toInt();
+  const int OutputNumber = server.arg("outputNumber").toInt();
   QueueMessage msg = {
     .id = QueueMsgId::DeleteModule,
-    .module = { .index = ModuleIndex }
+    .module = { .outputNumber = OutputNumber }
   };
   (void) HapticSettings::Instance().addMessage(&msg);
 
@@ -366,7 +366,7 @@ void WebInterface::onAddModule()
     QueueMessage msg = {
       .id = QueueMsgId::CreateModule,
       .module = { 
-        .index = data["outputNumber"].as<int>(),
+        .outputNumber  = data["outputNumber"].as<int>(),
         .value = { .i = data["type"].as<int>() }
       }
     };


### PR DESCRIPTION
Fixes issues that were occurring when editing outputs other than output 1. Incorrect output being muted, modules not getting deleted, and other similar issues were all being caused by inconsistent usage of index vs. output number when editing and deleting modules. This PR switches to just using output number as the source of truth across the web app and backend.